### PR TITLE
Ensure both datasets are loaded before listening for updates.

### DIFF
--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox.ts
@@ -297,6 +297,7 @@ export class CourierInbox extends HTMLElement {
 
   private async load(props: { feedType: CourierInboxFeedType, canUseCache: boolean }) {
     await CourierInboxDatastore.shared.load(props);
+    await CourierInboxDatastore.shared.listenForUpdates();
   }
 
   public refresh() {


### PR DESCRIPTION
See https://linear.app/trycourier/issue/C-14049/blockingcourier-ui-inbox-inboxarchive-dataset-may-not-be-loaded-before

Fixes an issue where a WS event may come through for a message in an unloaded dataset, and we can't properly update it (ex. unarchiving a message before the archived messages have appeared on screen).