### PR TITLE
Set fallback "created" timestamp for new messages.

### DIFF
--- a/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
+++ b/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
@@ -4,6 +4,7 @@ import { UUID } from '../utils/uuid';
 import { CourierSocket } from './courier-socket';
 import { TransactionManager } from './courier-inbox-transaction-manager';
 import { CLOSE_CODE_NORMAL_CLOSURE } from '../types/socket/protocol/v1/errors';
+import { fixMessageEventEnvelope } from './inbox-message-utils';
 
 /** Application-layer implementation of the Courier WebSocket API for Inbox messages. */
 export class CourierInboxSocket extends CourierSocket {
@@ -89,8 +90,9 @@ export class CourierInboxSocket extends CourierSocket {
     // Handle message events, calling all registered listeners.
     if ('event' in data && CourierInboxSocket.isInboxMessageEvent(data.event)) {
       const envelope: InboxMessageEventEnvelope = data as InboxMessageEventEnvelope;
+      const fixedEnvelope = fixMessageEventEnvelope(envelope);
       for (const listener of this.messageEventListeners) {
-        listener(envelope);
+        listener(fixedEnvelope);
       }
     }
 

--- a/@trycourier/courier-js/src/socket/inbox-message-utils.ts
+++ b/@trycourier/courier-js/src/socket/inbox-message-utils.ts
@@ -1,0 +1,39 @@
+import { InboxMessage } from "../types/inbox";
+import { InboxMessageEvent, InboxMessageEventEnvelope } from "../types/socket/protocol/v1/messages";
+
+/**
+ * Ensure the `created` timestamp is set for a new message.
+ *
+ * New messages received from the WebSocket may not have a created time,
+ * until they are retrieved from the GraphQL API.
+ *
+ * @param envelope - The envelope containing the message event.
+ * @returns The envelope with the created time set.
+ */
+function ensureCreatedTime(envelope: InboxMessageEventEnvelope): InboxMessageEventEnvelope {
+  if (envelope.event === InboxMessageEvent.NewMessage) {
+    const message = envelope.data as InboxMessage;
+
+    if (!message.created) {
+      message.created = new Date().toISOString();
+    }
+
+    return {
+      ...envelope,
+      data: message,
+    };
+  }
+
+  return envelope;
+}
+
+/**
+ * Apply fixes to a message event envelope.
+ *
+ * @param envelope - The envelope containing the message event.
+ * @returns The envelope with the fixes applied.
+ */
+export function fixMessageEventEnvelope(envelope: InboxMessageEventEnvelope): InboxMessageEventEnvelope {
+  // Apply any fixes to the message event envelope.
+  return ensureCreatedTime(envelope);
+}

--- a/@trycourier/courier-ui-inbox/src/utils/utils.ts
+++ b/@trycourier/courier-ui-inbox/src/utils/utils.ts
@@ -66,6 +66,7 @@ export function getMessageTime(message: InboxMessage): string {
   const messageDate = new Date(message.created);
   const diffInSeconds = Math.floor((now.getTime() - messageDate.getTime()) / 1000);
 
+  if (diffInSeconds < 5) return 'Now';
   if (diffInSeconds < 60) return `${diffInSeconds}s`;
   if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}m`;
   if (diffInSeconds < 86400) return `${Math.floor(diffInSeconds / 3600)}h`;


### PR DESCRIPTION
New messages received over the WebSocket have no `created` timestamp field, which causes sorting issues.

Repro for unarchive ordering issue:

* Open Inbox 1 for User A
* Send a message to User A
* Open Inbox 2 for User A
* In Inbox 2, archive the new message then unarchive the new message
* Inbox 1 inserts the new message at the end/bottom of the inbox, when it should be at the beginning/top

This also preserves the "Now" friendly-time for messages received in the last 5s.

See https://linear.app/trycourier/issue/C-14266