### PR TITLE
Remove CourierSocket from top level exports.

### DIFF
--- a/@trycourier/courier-js/src/index.ts
+++ b/@trycourier/courier-js/src/index.ts
@@ -38,7 +38,6 @@ import {
   InboxMessage,
   InboxAction,
 } from './types/inbox';
-import { CourierSocket } from './socket/courier-socket';
 import { InboxMessageEvent, InboxMessageEventEnvelope } from './types/socket/protocol/v1/messages';
 
 // Client
@@ -80,7 +79,6 @@ export {
   PreferenceClient,
   InboxClient,
   ListClient,
-  CourierSocket
 };
 
 // Listeners


### PR DESCRIPTION
Consumers shouldn't instantiate this themselves. The singleton is accessed via `Courier.shared.client.inbox.socket`