### PR TITLE
Allow any created date passed to the inbox message listener.

### DIFF
--- a/@trycourier/courier-js/src/__tests__/courier-inbox-socket.test.ts
+++ b/@trycourier/courier-js/src/__tests__/courier-inbox-socket.test.ts
@@ -151,7 +151,7 @@ describe('CourierInboxSocket', () => {
         ...messageEvent,
         data: {
           ...messageEvent.data,
-          created: new Date().toISOString(),
+          created: expect.any(String),
         },
       };
 


### PR DESCRIPTION
There can be small discrepancies between the `created` date in the CourierInboxSocket implementation and the `new Date()` crated in the test. Asserting `created` is present rather than an exact value de-flakes the test.