### PR TITLE
Add @types/jest where jest is used for globals in the text editor.

### DIFF
--- a/@trycourier/courier-js/package.json
+++ b/@trycourier/courier-js/package.json
@@ -26,6 +26,7 @@
     "dist"
   ],
   "devDependencies": {
+    "@types/jest": "29.5.14",
     "dotenv": "16.4.7",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",

--- a/@trycourier/courier-ui-inbox/package.json
+++ b/@trycourier/courier-ui-inbox/package.json
@@ -30,6 +30,7 @@
     "@trycourier/courier-ui-core": "1.0.9-beta"
   },
   "devDependencies": {
+    "@types/jest": "29.5.14",
     "@trycourier/courier-js": "file:../@trycourier/courier-js",
     "@trycourier/courier-ui-core": "file:../@trycourier/courier-ui-core",
     "jest": "^29.7.0",


### PR DESCRIPTION
Was removed in https://github.com/trycourier/courier-web/pull/30/files#diff-5341fa77a4f72a68b7a601fd564fbf435efb69e9be2773df100e5de93ff72dc6L29

The types are required for text editors to recognize Jest's globals (`expect`, `describe`, etc)