### PR TITLE
Send accountId in subscribe message if tenantId is used.

### DIFF
--- a/@trycourier/courier-js/src/__tests__/courier-inbox-socket.test.ts
+++ b/@trycourier/courier-js/src/__tests__/courier-inbox-socket.test.ts
@@ -75,6 +75,29 @@ describe('CourierInboxSocket', () => {
         },
       });
     });
+
+    it('should send a subscribe request with an accountId if a sub-tenant ID is specified', async () => {
+      const subTenantId = 'test-sub-tenant-id';
+      const socket = new CourierInboxSocket({ ...OPTIONS, tenantId: subTenantId });
+
+      socket.connect();
+      await mockServer.connected;
+
+      await expect(mockServer).toReceiveMessage({
+        action: 'get-config',
+        tid: expect.any(String),
+      });
+
+      await expect(mockServer).toReceiveMessage({
+        action: 'subscribe',
+        tid: expect.any(String),
+        data: {
+          channel: 'test',
+          event: '*',
+          accountId: subTenantId,
+        },
+      });
+    });
   });
 
   describe('onMessageReceived', () => {

--- a/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
+++ b/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
@@ -119,13 +119,20 @@ export class CourierInboxSocket extends CourierSocket {
    * Subscribes to all events for the user.
    */
   public sendSubscribe(): void {
+    const data: Record<string, any> = {
+      channel: this.userId,
+      event: '*',
+    };
+
+    // Set accountId to the sub-tenant ID if it is specified.
+    if (this.subTenantId) {
+      data.accountId = this.subTenantId;
+    }
+
     const envelope: ClientMessageEnvelope = {
       tid: UUID.nanoid(),
       action: ClientAction.Subscribe,
-      data: {
-        channel: this.userId,
-        event: '*'
-      },
+      data,
     };
 
     this.send(envelope);

--- a/@trycourier/courier-js/src/socket/courier-socket.ts
+++ b/@trycourier/courier-js/src/socket/courier-socket.ts
@@ -177,6 +177,11 @@ export abstract class CourierSocket {
     return this.options.userId;
   }
 
+  /** The sub-tenant ID, if specified by the user. */
+  protected get subTenantId(): string | undefined {
+    return this.options.tenantId;
+  }
+
   protected get logger(): Logger | undefined {
     return this.options.logger;
   }


### PR DESCRIPTION
https://linear.app/trycourier/issue/C-14427

Pass on the `tenantId` option to the `subscribe` WebSocket message to down-scope messages received to a sub-tenant.