### PR TITLE
Mock getArchivedMessages resolved value in datastore tests.

### DIFF
--- a/@trycourier/courier-ui-inbox/src/datastore/__tests__/datastore.test.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/__tests__/datastore.test.ts
@@ -54,6 +54,24 @@ describe("CourierInboxDatastore", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Default mock responses for the datastore (no messages in the inbox or archive).
+    mockGetMessages.mockResolvedValue({
+      data: {
+        count: 0,
+        messages: {
+          nodes: [],
+        },
+      },
+    });
+    mockGetArchivedMessages.mockResolvedValue({
+      data: {
+        count: 0,
+        messages: {
+          nodes: [],
+        },
+      },
+    });
   });
 
   describe('archiveAllMessages', () => {


### PR DESCRIPTION
Fixes an error referencing fields (ex. `data`) on the response from `getArchivedMessages`, since it's called when the datastore is loaded.

https://github.com/trycourier/courier-web/blob/1de3d119496d7811b37d14ddede6cca168da5d76/%40trycourier/courier-ui-inbox/src/datastore/datastore.ts#L63

`response` should always be defined - `getMessages` and `getArchivedMessages` have a non-null return type signatures: https://github.com/trycourier/courier-web/blob/1de3d119496d7811b37d14ddede6cca168da5d76/%40trycourier/courier-js/src/client/inbox-client.ts#L76

