### PR TITLE
Handle WebSocket close/error events and client close requests.

### DIFF
--- a/@trycourier/courier-js/src/shared/courier.ts
+++ b/@trycourier/courier-js/src/shared/courier.ts
@@ -66,6 +66,13 @@ export class Courier {
    * @param options - The options for the Courier client
    */
   public signIn(props: CourierProps) {
+    // Sign out any existing user.
+    if (this.instanceClient) {
+      this.instanceClient.options.logger.warn('Sign in called but there is already a user signed in. Signing out the current user.');
+      this.signOut();
+    }
+
+    // Create a new client.
     const connectionId = props.connectionId ?? UUID.nanoid();
     this.instanceClient = new CourierClient({ ...props, connectionId });
     this.notifyAuthenticationListeners({ userId: props.userId });
@@ -75,6 +82,10 @@ export class Courier {
    * Sign out of Courier
    */
   public signOut() {
+    // Close the socket client.
+    this.instanceClient?.inbox.socket?.close();
+
+    // Clear the client.
     this.instanceClient = undefined;
     this.notifyAuthenticationListeners({ userId: undefined });
   }

--- a/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
+++ b/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
@@ -106,6 +106,15 @@ export class CourierInboxSocket extends CourierSocket {
   }
 
   public onClose(_: CloseEvent): Promise<void> {
+    // Cancel scheduled pings.
+    this.clearPingInterval();
+
+    // Remove any message event listeners.
+    this.clearMessageEventListeners();
+
+    // Clear any outstanding pings.
+    this.pingTransactionManager.clearOutstandingRequests();
+
     return Promise.resolve();
   }
 
@@ -220,13 +229,17 @@ export class CourierInboxSocket extends CourierSocket {
    * Restart the ping interval, clearing the previous interval if it exists.
    */
   private restartPingInterval(): void {
-    if (this.pingIntervalId) {
-      window.clearInterval(this.pingIntervalId);
-    }
+    this.clearPingInterval();
 
     this.pingIntervalId = window.setInterval(() => {
       this.sendPing();
     }, this.pingInterval);
+  }
+
+  private clearPingInterval(): void {
+    if (this.pingIntervalId) {
+      window.clearInterval(this.pingIntervalId);
+    }
   }
 
   private get pingInterval(): number {
@@ -248,6 +261,13 @@ export class CourierInboxSocket extends CourierSocket {
 
   private setConfig(config: Config): void {
     this.config = config;
+  }
+
+  /**
+   * Removes all message event listeners.
+   */
+  private clearMessageEventListeners(): void {
+    this.messageEventListeners = [];
   }
 
   private static isInboxMessageEvent(event: string): event is InboxMessageEvent {

--- a/examples/next-latest/src/app/socket-reconnect/layout.tsx
+++ b/examples/next-latest/src/app/socket-reconnect/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+import "../globals.css";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+export const metadata: Metadata = {
+  title: "Next Latest",
+  description: "The latest version of Next.js",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/examples/next-latest/src/app/socket-reconnect/page.tsx
+++ b/examples/next-latest/src/app/socket-reconnect/page.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useEffect, useState } from 'react';
+import { useCourier, CourierInbox, CourierInboxListItemFactoryProps } from '@trycourier/courier-react';
+
+export default function Home() {
+  const SIGN_IN_COUNT = 3;
+  const SIGN_IN_DELAY_MS = 0;
+
+  const courier = useCourier();
+  const [signInCount, setSignInCount] = useState(0);
+
+  // This is an intentional bug to reproduce an error condition - we call signIn several times for the same user.
+  // This causes:
+  //   1. The Inbox socket connection to be closed and reopened.
+  //   2. Inbox messages to be refreshed from the server.
+  //   3. The UI to reload several times.
+  useEffect(() => {
+    if (signInCount < SIGN_IN_COUNT) {
+      courier.shared.signIn({
+        userId: process.env.NEXT_PUBLIC_USER_ID!,
+        jwt: process.env.NEXT_PUBLIC_JWT!,
+      });
+
+      setTimeout(() => {
+        setSignInCount(c => c + 1);
+      }, SIGN_IN_DELAY_MS);
+    }
+  }, [signInCount]);
+
+  return (
+    <div>
+      <div>Sign In Count: {signInCount}</div>
+      <CourierInbox
+        onMessageClick={({ message, index }: CourierInboxListItemFactoryProps) => {
+          console.log(message);
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Also hooks into the `signIn`/`signOut` logic:
 * Closes the connection when the client signs out
 * Signs out (with a warning) if sign in is called when a user is already signed in

Handling the close event for a clean shutdown (the case where the client _wants_ to close the connection) amounts to:
 * Differentiating a client-requested close from the error case -- the two may look alike if the client requests `close` before the connection is open, as may happen if `signIn` is called multiple times in quick succession
 * Cancelling any scheduled retries, pings, and cleaning up any associated state