### PR TITLE
Use package name in git tags to avoid collisions in monorepo.

### DIFF
--- a/scripts/release_package.sh
+++ b/scripts/release_package.sh
@@ -55,7 +55,7 @@ git push origin "$current_branch"
 
 # ── GitHub release ────────────────────────────────────────────────────────
 gum style --foreground 46 "Creating GitHub release…"
-gh release create "v$version" \
+gh release create "$package_name@v$version" \
   --title "$package_name@$version" \
   --notes "Release of $package_name@$version"
 


### PR DESCRIPTION
The first positional argument to `gh release create` is the tag name: https://cli.github.com/manual/gh_release_create