### PR TITLE
Use courier-react-components from workspace in dev and bundle in production.

### DIFF
--- a/@trycourier/courier-react/package.json
+++ b/@trycourier/courier-react/package.json
@@ -30,7 +30,7 @@
     "@trycourier/courier-js": "2.0.9-beta",
     "@trycourier/courier-ui-core": "1.0.11-beta",
     "@trycourier/courier-ui-inbox": "1.0.14-beta",
-    "@trycourier/courier-react-components": "file:../courier-react-components"
+    "@trycourier/courier-react-components": "1.0.0-beta"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/@trycourier/courier-react/vite.config.ts
+++ b/@trycourier/courier-react/vite.config.ts
@@ -42,7 +42,11 @@ export default defineConfig({
     rollupOptions: {
       // External dependencies that should not be bundled
       external: [
-        /^@trycourier\/.+/,
+        // Explicitly exclude Courier dependencies _except_ courier-react-components,
+        // which is not distributed independently.
+        /^@trycourier\/courier-js/,
+        /^@trycourier\/courier-ui-core/,
+        /^@trycourier\/courier-ui-inbox/,
         "react",
         "react-dom",
         "react-dom/client",
@@ -77,6 +81,7 @@ export default defineConfig({
     dts({
       insertTypesEntry: true,
       include: ["src/**/*.tsx"],
+      exclude: ['src/__tests__/**'],
     }) as PluginOption,
     // Bundle size visualization
     visualizer({


### PR DESCRIPTION
So changes to `courier-react-components` are picked up when it's changed in development, and it's bundled directly in prod (rather than marked external) since it's not published independently.