### PR TITLE
Explicitly resolve React modules in Jest test config.

### DIFF
--- a/@trycourier/courier-react-17/jest.config.ts
+++ b/@trycourier/courier-react-17/jest.config.ts
@@ -29,6 +29,11 @@ export default /** @type {import('ts-jest').JestConfigWithTsJest} */ ({
 
   // Module resolution
   moduleDirectories: ['node_modules', 'src'],
+  moduleNameMapper: {
+    '^react$': require.resolve('react'),
+    '^react-dom$': require.resolve('react-dom'),
+    '^react/jsx-runtime$': require.resolve('react/jsx-runtime'),
+  },
 
   // Test environment options
   testEnvironmentOptions: {

--- a/@trycourier/courier-react-17/package.json
+++ b/@trycourier/courier-react-17/package.json
@@ -37,9 +37,9 @@
     "react-dom": ">=17.0.0, <18.0.0"
   },
   "devDependencies": {
-    "@testing-library/dom": "^10.0.0",
+    "@testing-library/dom": "^8.20.1",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.12",
     "@types/react": "17.0.2",

--- a/@trycourier/courier-react/jest.config.ts
+++ b/@trycourier/courier-react/jest.config.ts
@@ -29,6 +29,11 @@ export default /** @type {import('ts-jest').JestConfigWithTsJest} */ ({
 
   // Module resolution
   moduleDirectories: ['node_modules', 'src'],
+  moduleNameMapper: {
+    '^react$': require.resolve('react'),
+    '^react-dom$': require.resolve('react-dom'),
+    '^react/jsx-runtime$': require.resolve('react/jsx-runtime'),
+  },
 
   // Test environment options
   testEnvironmentOptions: {


### PR DESCRIPTION
So React versions aren't conflicting between `courier-react-components` and each of `courier-react`/`courier-react-17`.

Also uses the compatible version of `@testing-library/react` for React 17 (https://github.com/testing-library/react-testing-library/issues/1121#issuecomment-1242335979)

Run tests with:

```sh
yarn workspace @trycourier/courier-react run test
yarn workspace @trycourier/courier-react-17 run test
```