### PR TITLE
Move courier-react-components to devDependencies.

### DIFF
--- a/@trycourier/courier-react-17/package.json
+++ b/@trycourier/courier-react-17/package.json
@@ -28,7 +28,6 @@
   "license": "MIT",
   "dependencies": {
     "@trycourier/courier-js": "2.0.10",
-    "@trycourier/courier-react-components": "1.0.0",
     "@trycourier/courier-ui-core": "1.0.12",
     "@trycourier/courier-ui-inbox": "1.0.15"
   },
@@ -41,6 +40,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.6.1",
+    "@trycourier/courier-react-components": "1.0.0",
     "@types/jest": "^29.5.12",
     "@types/react": "17.0.2",
     "@types/react-dom": "17.0.2",

--- a/@trycourier/courier-react-components/package.json
+++ b/@trycourier/courier-react-components/package.json
@@ -16,22 +16,17 @@
   "author": "Courier",
   "license": "MIT",
   "peerDependencies": {
-    "@trycourier/courier-js": "2.0.9",
-    "@trycourier/courier-ui-core": "1.0.11",
-    "@trycourier/courier-ui-inbox": "1.0.14"
+    "@trycourier/courier-js": "2.0.10",
+    "@trycourier/courier-ui-core": "1.0.12",
+    "@trycourier/courier-ui-inbox": "1.0.15"
   },
   "devDependencies": {
-    "@trycourier/courier-js": "2.0.9",
-    "@trycourier/courier-ui-core": "1.0.11",
-    "@trycourier/courier-ui-inbox": "1.0.14",
+    "@trycourier/courier-js": "2.0.10",
+    "@trycourier/courier-ui-core": "1.0.12",
+    "@trycourier/courier-ui-inbox": "1.0.15",
     "@types/react": "17.0.2",
     "@types/react-dom": "17.0.2",
     "react": "17.0.2",
     "react-dom": "17.0.2"
-  },
-  "dependencies": {
-    "@trycourier/courier-js": "2.0.9",
-    "@trycourier/courier-ui-core": "1.0.11",
-    "@trycourier/courier-ui-inbox": "1.0.14"
   }
 }

--- a/@trycourier/courier-react/package.json
+++ b/@trycourier/courier-react/package.json
@@ -28,7 +28,6 @@
   "license": "MIT",
   "dependencies": {
     "@trycourier/courier-js": "2.0.10",
-    "@trycourier/courier-react-components": "1.0.0",
     "@trycourier/courier-ui-core": "1.0.12",
     "@trycourier/courier-ui-inbox": "1.0.15"
   },
@@ -41,6 +40,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@trycourier/courier-react-components": "1.0.0",
     "@types/jest": "^29.5.12",
     "@types/react": "19.1.8",
     "@types/react-dom": "19.1.6",

--- a/examples/next-latest/package.json
+++ b/examples/next-latest/package.json
@@ -12,7 +12,7 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@trycourier/courier-react": "8.0.24"
+    "@trycourier/courier-react": "8.0.25"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
Putting it in `dependencies` will make npm try to install it, even though it isn't a public package and isn't needed at runtime (in production)