### PR TITLE
Bump respective dev/peer/prod dependency entry when a dep is updated.

### DIFF
--- a/scripts/bump_dependencies.sh
+++ b/scripts/bump_dependencies.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # Usage: ./bump_dependencies.sh @scope/package
 ########################################
 
-package_name="$1"                       # e.g. @trycourier/courier-js
+# e.g. @trycourier/courier-js
+package_name="$1"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ── read the new version from THAT package’s package.json ───────────────
@@ -14,14 +15,54 @@ gum style --foreground 46 "Updating dependencies for $package_name@$new_version"
 
 # helper – updates deps in every target dir passed in
 update_deps () {
-  local targets=("$@")                  # array of package folders (no scope)
+  # array of package folders (no scope)
+  local targets=("$@")
   for target in "${targets[@]}"; do
-    local dep_dir="$script_dir/../@trycourier/$target"
-    if [[ -d "$dep_dir" ]]; then
-      gum style --foreground 21 " ↳ $target → $package_name@$new_version"
-      ( cd "$dep_dir" && npm pkg set "dependencies.$package_name=$new_version" )
-    fi
+    update_all_deps_for_package "$target" "$package_name" "$new_version"
   done
+}
+
+# Usage: update_all_deps_for_package courier-ui-inbox @trycourier/courier-js 2.0.0
+# For a given target, package name, and version, update dependencies, devDependencies, and/or peerDependencies if present
+update_all_deps_for_package () {
+  local target="$1"
+  local package_name="$2"
+  local package_version="$3"
+  local dep_dir="$script_dir/../@trycourier/$target"
+
+  # Return early if dep_dir does not exist
+  [[ -d "$dep_dir" ]] || return
+
+  local pkg_json="$dep_dir/package.json"
+  # Return early if package.json does not exist
+  [[ -f "$pkg_json" ]] || return
+
+  local updated=0
+
+  # Check and update dependencies
+  if node -e "const p=require('$pkg_json');process.exit(p.dependencies && p.dependencies['$package_name'] ? 0 : 1)"; then
+    gum style --foreground 21 " ↳ $target → dependencies.$package_name@$package_version"
+    ( cd "$dep_dir" && npm pkg set "dependencies.$package_name=$package_version" )
+    updated=1
+  fi
+
+  # Check and update devDependencies
+  if node -e "const p=require('$pkg_json');process.exit(p.devDependencies && p.devDependencies['$package_name'] ? 0 : 1)"; then
+    gum style --foreground 36 " ↳ $target → devDependencies.$package_name@$package_version"
+    ( cd "$dep_dir" && npm pkg set "devDependencies.$package_name=$package_version" )
+    updated=1
+  fi
+
+  # Check and update peerDependencies
+  if node -e "const p=require('$pkg_json');process.exit(p.peerDependencies && p.peerDependencies['$package_name'] ? 0 : 1)"; then
+    gum style --foreground 99 " ↳ $target → peerDependencies.$package_name@$package_version"
+    ( cd "$dep_dir" && npm pkg set "peerDependencies.$package_name=$package_version" )
+    updated=1
+  fi
+
+  if [[ $updated -eq 0 ]]; then
+    gum style --foreground 244 " ↳ $target: $package_name not found in dependencies"
+  fi
 }
 
 # ── route by the *source* package we just published ─────────────────────


### PR DESCRIPTION
Conditionally updates the `dependencies`, `peerDependencies`, and/or `devDependencies` entries in a dependent's package.json, if an outdated version of the dependency exists.

Previously `dependencies` was only and always updated, which led to `dependencies` being introduced and `devDependencies` not being updated, ex. in the case of `courier-react` having a dev dependency on `courier-react-components`.

Sample output:
<img width="848" height="75" alt="Screenshot 2025-08-01 at 10 28 45 AM" src="https://github.com/user-attachments/assets/efe95300-81af-4790-bc6b-ed73033d0853" />
