### PR TITLE
Remove applyMessageSnapshot call in openMessage success case.

### DIFF
--- a/@trycourier/courier-ui-inbox/src/datastore/datastore.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/datastore.ts
@@ -405,7 +405,6 @@ export class CourierInboxDatastore {
 
     try {
       snapshot.message.opened = new Date().toISOString();
-      this.applyMessageSnapshot(snapshot);
       if (canCallApi) {
         await Courier.shared.client?.inbox.open({ messageId: message.messageId });
       }


### PR DESCRIPTION
Fixes an issue where the unread count is incremented 2x for a single new message in the success case (see https://linear.app/trycourier/issue/C-14696).

`applyMessageSnapshot` changes the unread count, which isn't necessary unless the count previously changed and needs to be reverted. A follow up could update `applyMessageSnapshot` to restore to a last known good state (full snapshot) rather than manually compute changes to the unread count.