### PR TITLE
Pull from origin and create a non-main branch for releasing.

### DIFF
--- a/scripts/check_git.sh
+++ b/scripts/check_git.sh
@@ -24,5 +24,15 @@ if [ "$current_branch" != "main" ]; then
   exit 1
 fi
 
+# Check if there are any changes
+if [ -n "$(git status --porcelain)" ]; then
+  gum style --foreground 196 "There are uncommitted changes. Please commit or stash them."
+  exit 1
+fi
+
 # Print success message
-gum style --foreground 46 "Current branch is main"
+gum style --foreground 46 "Current branch is main and there are no uncommitted changes"
+
+# Pull origin/main
+gum confirm "Running git pull origin main" && git pull origin main
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Run git checks
+# Check we're on main
 sh "$(dirname "$0")/check_git.sh" || exit 1
 
-# Run git checks
+# Increment the major/minor/patch version of the package
 sh "$(dirname "$0")/incremement_version.sh" "$1" || exit 1
 
-# Run push release
+# Release to npm and create a GitHub release
 sh "$(dirname "$0")/release_package.sh" "$1" || exit 1

--- a/scripts/release_package.sh
+++ b/scripts/release_package.sh
@@ -85,5 +85,16 @@ gum style --border normal --border-foreground 212 --padding "0 1" "$(
   gum style --foreground 212 "   npm i $package_name@$version"
 )"
 
+# ── return to main and prompt to review/merge PR ──────────────────────────
+gum style --foreground 208 "Switching back to main branch."
+git checkout main
+
+gum style --foreground 208 "Please review and merge the PR for $release_branch into main:"
+gum style --foreground 51 "  https://github.com/$(git config --get remote.origin.url | sed -E 's/.*github.com[/:](.*)\.git/\1/')/pulls"
+gum confirm "Have you reviewed and merged the PR?" || {
+  gum style --foreground 196 "Please review and merge the PR before continuing."
+  exit 1
+}
+
 # ── bump internal dependencies ────────────────────────────────────────────
 bash "$script_dir/bump_dependencies.sh" "$package_name"

--- a/scripts/release_package.sh
+++ b/scripts/release_package.sh
@@ -90,7 +90,10 @@ gum style --foreground 208 "Switching back to main branch."
 git checkout main
 
 gum style --foreground 208 "Please review and merge the PR for $release_branch into main:"
+
+# Prints "https://github.com/{org}/{repo}/pulls"
 gum style --foreground 51 "  https://github.com/$(git config --get remote.origin.url | sed -E 's/.*github.com[/:](.*)\.git/\1/')/pulls"
+
 gum confirm "Have you reviewed and merged the PR?" || {
   gum style --foreground 196 "Please review and merge the PR before continuing."
   exit 1

--- a/scripts/release_package.sh
+++ b/scripts/release_package.sh
@@ -37,9 +37,6 @@ fi
 # ── read package version ──────────────────────────────────────────────────
 version=$(node -p "require('$package_dir/package.json').version")
 
-# ── current Git branch ────────────────────────────────────────────────────
-current_branch=$(git branch --show-current)
-
 # ── user confirmation ─────────────────────────────────────────────────────
 gum style --foreground 208 "About to release $package_name@$version. This will:"
 gum style --foreground 208 "  1. Commit & push changes"
@@ -47,11 +44,20 @@ gum style --foreground 208 "  2. Create a GitHub release"
 gum style --foreground 208 "  3. Publish to npm"
 gum confirm "Proceed?" || { gum style --foreground 196 "Release cancelled"; exit 1; }
 
+# ── create release branch ─────────────────────────────────────────────────
+release_branch="release-$package_name-$version"
+gum style --foreground 208 "Creating release branch ($release_branch)."
+git checkout -b "$release_branch"
+
+# ── open PR ───────────────────────────────────────────────────────────────
+gum style --foreground 208 "Opening PR to merge $release_branch into main"
+gh pr create --base main --head "$release_branch" --title "chore: release $package_name@$version" --body "Release of $package_name@$version"
+
 # ── Git commit & push ─────────────────────────────────────────────────────
 gum style --foreground 46 "Pushing changes to git…"
 git add .
 git commit -m "chore: release $package_name@$version" || true  # no-op if nothing to commit
-git push origin "$current_branch"
+git push origin "$release_branch"
 
 # ── GitHub release ────────────────────────────────────────────────────────
 gum style --foreground 46 "Creating GitHub release…"


### PR DESCRIPTION
Integrates releasing (and release changes) with the PR review/approval process, so we can review changes made during the release and turn on PR requirements to merge to main.

Rather than creating the release on `main` and pushing to `main` directly this instead will:

1. Check the client is on `main` and pull any new changes from the remote
2. Create and switch to a release branch (ex. `release-@trycourier/courier-js@1.2.3`)
3. Commit the changes, push the branch, open a PR
4. Perform the release
5. Switch back to main and prompt to merge the PR into main before continuing (only new manual step)

After step 4, if there are more packages to release (ex. dependent packages) step 1 will pull the latest changes and repeat the process