### PR TITLE
Default showLogs to false (avoid using process.env).

### DIFF
--- a/@trycourier/courier-js/README.md
+++ b/@trycourier/courier-js/README.md
@@ -21,7 +21,7 @@ const courierClient = new CourierClient({
     userId: 'some_user_id', // The user id for your user. This is usually the user id you maintain in your system for a user.
     jwt: 'ey...n0',         // The access token associated with the user.
     tenantId: 'asdf',       // [OPTIONAL] Allows you to scope a client to a specific tenant. If you didn't configure multi-tenant routing, you probably don't need this.
-    showLogs: true,         // [OPTIONAL] Shows debugging logs from the client. Defaults to process.env.NODE_ENV === 'development'.
+    showLogs: true,         // [OPTIONAL] Shows debugging logs from the client. Defaults to `false`.
 });
 ```
 
@@ -34,7 +34,7 @@ Courier.shared.signIn({
     userId: 'some_user_id', // The user id for your user. This is usually the user id you maintain in your system for a user.
     jwt: 'ey...n0',         // The access token associated with the user.
     tenantId: 'asdf',       // [OPTIONAL] Allows you to scope a client to a specific tenant. If you didn't configure multi-tenant routing, you probably don't need this.
-    showLogs: true,         // [OPTIONAL] Shows debugging logs from the client. Defaults to process.env.NODE_ENV === 'development'.
+    showLogs: true,         // [OPTIONAL] Shows debugging logs from the client. Defaults to `false`.
 });
 
 Courier.shared.signOut();

--- a/@trycourier/courier-js/src/client/courier-client.ts
+++ b/@trycourier/courier-js/src/client/courier-client.ts
@@ -70,8 +70,8 @@ export class CourierClient extends Client {
   public readonly tracking: TrackingClient;
 
   constructor(props: CourierProps) {
-    // Determine if we should show logs based on props or environment
-    const showLogs = props.showLogs !== undefined ? props.showLogs : process.env.NODE_ENV === 'development';
+    // Determine if we should show logs (default to false)
+    const showLogs = props.showLogs !== undefined ? props.showLogs : false;
 
     // Setup base options with default values
     const baseOptions = {


### PR DESCRIPTION
Removing calls to `process.env` makes the bundles usable without compilation. With all Node-specific variables removed, consumers can do the following to use the modules directly in vanilla HTML:

```html
<script type="importmap">
    {
      "imports": {
        "@trycourier/courier-ui-inbox": "https://unpkg.com/@trycourier/courier-ui-inbox/dist/index.mjs",
        "@trycourier/courier-js": "https://unpkg.com/@trycourier/courier-js/dist/index.mjs",
        "@trycourier/courier-js-core": "https://unpkg.com/@trycourier/courier-js-core/dist/index.mjs"
      }
    }
  </script>
```