### PR TITLE
Remove feedType prop from React load hook.

### DIFF
--- a/@trycourier/courier-react-components/src/hooks/use-courier.tsx
+++ b/@trycourier/courier-react-components/src/hooks/use-courier.tsx
@@ -9,7 +9,7 @@ type AuthenticationHooks = {
 }
 
 type InboxHooks = {
-  load: (props?: { feedType: CourierInboxFeedType, canUseCache: boolean }) => Promise<void>,
+  load: (props?: { canUseCache: boolean }) => Promise<void>,
   fetchNextPageOfMessages: (props: { feedType: CourierInboxFeedType }) => Promise<InboxDataSet | null>,
   setPaginationLimit: (limit: number) => void,
   readMessage: (message: InboxMessage) => Promise<void>,
@@ -35,7 +35,7 @@ export const useCourier = () => {
   const signOut = () => Courier.shared.signOut();
 
   // Inbox Functions
-  const loadInbox = (props?: { feedType: CourierInboxFeedType, canUseCache: boolean }) => CourierInboxDatastore.shared.load(props);
+  const loadInbox = (props?: { canUseCache: boolean }) => CourierInboxDatastore.shared.load(props);
   const fetchNextPageOfMessages = (props: { feedType: CourierInboxFeedType }) => CourierInboxDatastore.shared.fetchNextPageOfMessages(props);
   const setPaginationLimit = (limit: number) => Courier.shared.paginationLimit = limit;
   const readMessage = (message: InboxMessage) => CourierInboxDatastore.shared.readMessage({ message });


### PR DESCRIPTION
`feedType` is no longer a prop on the underlying datastore method: https://github.com/trycourier/courier-web/blob/8810c3706f7dc00ae79d1840b6db5059033cc404/%40trycourier/courier-ui-inbox/src/datastore/datastore.ts#L80