### PR TITLE
Remove connectionId from CourierProps.

### DIFF
--- a/@trycourier/courier-js/src/__tests__/courier-client.test.ts
+++ b/@trycourier/courier-js/src/__tests__/courier-client.test.ts
@@ -1,13 +1,21 @@
 import { CourierClient } from '../index';
+import { UUID } from '../utils/uuid';
+
+const nanoidSpy = jest.spyOn(UUID, "nanoid");
+
+const CONNECTION_ID = "mock-connection-id";
 
 describe('CourierClient', () => {
+
+  beforeEach(() => {
+    nanoidSpy.mockReturnValue(CONNECTION_ID);
+  });
 
   it('should validate client initialization with all options', () => {
     const testClient = new CourierClient({
       userId: process.env.USER_ID!,
       jwt: process.env.JWT!,
       publicApiKey: process.env.PUBLIC_API_KEY!,
-      connectionId: 'test-connection',
       tenantId: process.env.TENANT_ID,
       showLogs: true,
       apiUrls: {
@@ -25,7 +33,7 @@ describe('CourierClient', () => {
     expect(testClient.options.userId).toBe(process.env.USER_ID);
     expect(testClient.options.jwt).toBe(process.env.JWT);
     expect(testClient.options.publicApiKey).toBe(process.env.PUBLIC_API_KEY);
-    expect(testClient.options.connectionId).toBe('test-connection');
+    expect(testClient.options.connectionId).toBe(CONNECTION_ID);
     expect(testClient.options.tenantId).toBe(process.env.TENANT_ID);
     expect(testClient.options.showLogs).toBe(true);
     expect(testClient.options.apiUrls).toEqual({

--- a/@trycourier/courier-js/src/__tests__/utils.ts
+++ b/@trycourier/courier-js/src/__tests__/utils.ts
@@ -6,7 +6,6 @@ export function getClient(tenantId?: string) {
     publicApiKey: process.env.PUBLIC_API_KEY,
     jwt: process.env.JWT,
     tenantId: tenantId,
-    connectionId: process.env.INBOX_SOCKET_ID,
     apiUrls: {
       courier: {
         rest: process.env.COURIER_REST_URL!,

--- a/@trycourier/courier-js/src/client/courier-client.ts
+++ b/@trycourier/courier-js/src/client/courier-client.ts
@@ -8,6 +8,7 @@ import { TokenClient } from './token-client';
 import { Client } from './client';
 import { ListClient } from './list-client';
 import { TrackingClient } from './tracking-client';
+import { UUID } from '../utils/uuid';
 
 export interface CourierProps {
   /** User ID for the client. Normally matches the UID in your system */
@@ -18,9 +19,6 @@ export interface CourierProps {
 
   /** Public API key for testing (use JWTs in prod) */
   publicApiKey?: string;
-
-  /** Inbox Websocket connection ID */
-  connectionId?: string;
 
   /** Tenant ID. Used for multi-tenant apps */
   tenantId?: string;
@@ -43,7 +41,7 @@ export interface CourierClientOptions {
   readonly userId: string;
 
   /** Inbox Websocket connection ID */
-  readonly connectionId?: string;
+  readonly connectionId: string;
 
   /** Tenant ID. Used for multi-tenant apps */
   readonly tenantId?: string;
@@ -77,6 +75,7 @@ export class CourierClient extends Client {
     const baseOptions = {
       ...props,
       showLogs,
+      connectionId: UUID.nanoid(),
       apiUrls: props.apiUrls || getCourierApiUrls(),
       accessToken: props.jwt ?? props.publicApiKey
     };

--- a/@trycourier/courier-js/src/shared/courier.ts
+++ b/@trycourier/courier-js/src/shared/courier.ts
@@ -73,8 +73,7 @@ export class Courier {
     }
 
     // Create a new client.
-    const connectionId = props.connectionId ?? UUID.nanoid();
-    this.instanceClient = new CourierClient({ ...props, connectionId });
+    this.instanceClient = new CourierClient(props);
     this.notifyAuthenticationListeners({ userId: props.userId });
   }
 


### PR DESCRIPTION
The `connectionId` is an implementation detail between Courier SDKs and the Courier backends. Rather than having consumers optionally set an ID, the SDK will always generate one for a new client.