### PR TITLE
Report Courier UA over WS via query params.

### DIFF
--- a/@trycourier/courier-js/src/__tests__/courier-client.test.ts
+++ b/@trycourier/courier-js/src/__tests__/courier-client.test.ts
@@ -50,7 +50,7 @@ describe('CourierClient', () => {
       }
     });
     expect(testClient.options.courierUserAgent).toBeDefined();
-    expect(testClient.options.courierUserAgent.toJsonSerializable()).toEqual({
+    expect(testClient.options.courierUserAgent.getUserAgentInfo()).toEqual({
       [SDK_KEY]: "courier-js",
       [SDK_VERSION_KEY]: "test-version",  // from <package_root>/jest.config.ts
       [CLIENT_ID_KEY]: CONNECTION_ID,

--- a/@trycourier/courier-js/src/__tests__/courier-inbox-socket.test.ts
+++ b/@trycourier/courier-js/src/__tests__/courier-inbox-socket.test.ts
@@ -76,7 +76,6 @@ describe('CourierInboxSocket', () => {
       await expect(mockServer).toReceiveMessage({
         action: 'get-config',
         tid: expect.any(String),
-        stats: { ua: courierUserAgent.toJsonSerializable() },
       });
 
       await expect(mockServer).toReceiveMessage({
@@ -99,7 +98,6 @@ describe('CourierInboxSocket', () => {
       await expect(mockServer).toReceiveMessage({
         action: 'get-config',
         tid: expect.any(String),
-        stats: { ua: courierUserAgent.toJsonSerializable() },
       });
 
       await expect(mockServer).toReceiveMessage({

--- a/@trycourier/courier-js/src/__tests__/courier-socket.test.ts
+++ b/@trycourier/courier-js/src/__tests__/courier-socket.test.ts
@@ -93,6 +93,33 @@ describe('CourierSocket', () => {
 
       expect(connectionCount).toBe(1);
     });
+
+    it('should connect with correct URL query parameters', async () => {
+      const socket = new CourierSocketTestImplementation(OPTIONS);
+
+      // Spy on the WebSocket constructor to capture the URL
+      const originalWebSocket = global.WebSocket;
+      let capturedUrl: string = '';
+      global.WebSocket = jest.fn().mockImplementation((url) => {
+        capturedUrl = url;
+        return new originalWebSocket(url);
+      }) as any;
+
+      socket.connect();
+      await mockServer.connected;
+
+      // Restore the original WebSocket
+      global.WebSocket = originalWebSocket;
+
+      // Parse the URL to check query parameters
+      const url = new URL(capturedUrl);
+      expect(url.searchParams.get('auth')).toBe(OPTIONS.accessToken);
+      expect(url.searchParams.get('cid')).toBe(OPTIONS.connectionId);
+      expect(url.searchParams.get('iwpv')).toBe('v1');
+      expect(url.searchParams.get('userId')).toBe(OPTIONS.userId);
+      expect(url.searchParams.get('sdk')).toBe(USER_AGENT_CLIENT_NAME);
+      expect(url.searchParams.get('sdkv')).toBe(USER_AGENT_CLIENT_VERSION);
+    });
   });
 
   describe('message listener', () => {

--- a/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
+++ b/@trycourier/courier-js/src/socket/courier-inbox-socket.ts
@@ -220,9 +220,6 @@ export class CourierInboxSocket extends CourierSocket {
     const envelope: ClientMessageEnvelope = {
       tid: UUID.nanoid(),
       action: ClientAction.GetConfig,
-      stats: {
-        ua: this.courierUserAgent.toJsonSerializable(),
-      },
     };
 
     this.send(envelope);

--- a/@trycourier/courier-js/src/socket/courier-socket.ts
+++ b/@trycourier/courier-js/src/socket/courier-socket.ts
@@ -4,6 +4,7 @@ import { ServerMessage } from "../types/socket/protocol/messages";
 import { Logger } from "../utils/logger";
 import { CourierUserAgent } from "../utils/courier-user-agent";
 import { INBOX_WIRE_PROTOCOL_VERSION } from "./version";
+import { SDK_KEY, SDK_VERSION_KEY } from "../types/courier-user-agent";
 
 /**
  * Abstract base class for Courier WebSocket implementations.
@@ -275,7 +276,17 @@ export abstract class CourierSocket {
     const connectionId = this.options.connectionId;
     const userId = this.userId;
 
-    return `${this.url}?auth=${accessToken}&cid=${connectionId}&iwpv=${INBOX_WIRE_PROTOCOL_VERSION}&userId=${userId}`;
+    // Courier User-Agent info
+    const sdkName = this.courierUserAgent.getUserAgentInfo()[SDK_KEY];
+    const sdkVersion = this.courierUserAgent.getUserAgentInfo()[SDK_VERSION_KEY];
+
+    return `${this.url}?`
+      + `auth=${accessToken}&`
+      + `cid=${connectionId}&`
+      + `iwpv=${INBOX_WIRE_PROTOCOL_VERSION}&`
+      + `userId=${userId}&`
+      + `${SDK_KEY}=${sdkName}&`
+      + `${SDK_VERSION_KEY}=${sdkVersion}`;
   }
 
   /**

--- a/@trycourier/courier-js/src/types/courier-user-agent.ts
+++ b/@trycourier/courier-js/src/types/courier-user-agent.ts
@@ -1,6 +1,13 @@
 /** HTTP Header key used to report the Courier User-Agent. */
 export const HTTP_HEADER_KEY: string = "x-courier-ua" as const;
 
+/**
+ * HTTP query param key used to report the Courier User-Agent.
+ *
+ * Used in WebSocket Upgrade requests, where custom headers are not possible.
+ */
+export const HTTP_QUERY_PARAM_KEY: string = "cua" as const;
+
 export const SDK_KEY = "sdk" as const;
 export const SDK_VERSION_KEY = "sdkv" as const;
 export const CLIENT_ID_KEY = "cid" as const;

--- a/@trycourier/courier-js/src/utils/__tests__/courier-user-agent.test.ts
+++ b/@trycourier/courier-js/src/utils/__tests__/courier-user-agent.test.ts
@@ -11,7 +11,7 @@ describe("courier-user-agent", () => {
       it("should collect user agent, SDK name, SDK version, client ID", () => {
         const courierUserAgent = new CourierUserAgent(MOCK_CLIENT_ID, CLIENT_SDK_NAME, CLIENT_SDK_VERSION);
 
-        expect(courierUserAgent.toJsonSerializable()).toEqual({
+        expect(courierUserAgent.getUserAgentInfo()).toEqual({
           [SDK_KEY]: CLIENT_SDK_NAME,
           [SDK_VERSION_KEY]: CLIENT_SDK_VERSION,
           [CLIENT_ID_KEY]: MOCK_CLIENT_ID,
@@ -21,7 +21,7 @@ describe("courier-user-agent", () => {
       it("should produce a JSON-serializable object", () => {
         const courierUserAgent = new CourierUserAgent(MOCK_CLIENT_ID, CLIENT_SDK_NAME, CLIENT_SDK_VERSION);
 
-        const json = JSON.stringify(courierUserAgent.toJsonSerializable());
+        const json = JSON.stringify(courierUserAgent.getUserAgentInfo());
         const parsed = JSON.parse(json);
 
         expect(parsed).toBeDefined();

--- a/@trycourier/courier-js/src/utils/courier-user-agent.ts
+++ b/@trycourier/courier-js/src/utils/courier-user-agent.ts
@@ -1,24 +1,20 @@
-import { CourierUserAgent as TelemetryInterface, SDK_KEY, SDK_VERSION_KEY, CLIENT_ID_KEY } from "../types/courier-user-agent";
+import { CourierUserAgent as ICourierUserAgent, SDK_KEY, SDK_VERSION_KEY, CLIENT_ID_KEY } from "../types/courier-user-agent";
 
 /** Client info reportable to the Courier backend in WebSocket and HTTP requests. */
 export class CourierUserAgent {
-  /** Client ID for this session. */
-  private clientId: string;
-
-  /** Identifier of the SDK making requests to the Courier backend. */
-  private sdkName: string;
-
-  /** Version of the SDK making requests to the Courier backend. */
-  private sdkVersion: string;
-
-  constructor(clientId: string, callerSdkName: string, callerSdkVersion: string) {
-    this.clientId = clientId;
-    this.sdkName = callerSdkName;
-    this.sdkVersion = callerSdkVersion;
-  }
+  /**
+   * Create User Agent info
+   * @param clientId client ID for this session
+   * @param sdkName identifier of the SDK making requests to the Courier backend
+   * @param sdkVersion version of the SDK making requests to the Courier backend
+   */
+  constructor(
+    private readonly clientId: string,
+    private readonly sdkName: string,
+    private readonly sdkVersion: string) {}
 
   /** Get the telemetry payload as a JSON-serializable object. */
-  public toJsonSerializable(): TelemetryInterface {
+  public getUserAgentInfo(): ICourierUserAgent {
     return {
       [SDK_KEY]: this.sdkName,
       [SDK_VERSION_KEY]: this.sdkVersion,
@@ -28,7 +24,7 @@ export class CourierUserAgent {
 
   /** Get the telemetry payload as a comma-separated string, where keys and values are joined by `=`. */
   public toHttpHeaderValue(): string {
-    return Object.entries(this.toJsonSerializable())
+    return Object.entries(this.getUserAgentInfo())
       .map(([key, value]) => `${key}=${value}`)
       .join(',');
   }


### PR DESCRIPTION
Rather than via the `config` message.