### PR TITLE
Propagate events from render props and ensure ref exists at render time.

### DIFF
--- a/.changeset/fancy-masks-live.md
+++ b/.changeset/fancy-masks-live.md
@@ -1,0 +1,8 @@
+---
+"@trycourier/courier-react-components": patch
+"@trycourier/courier-react-17": patch
+"@trycourier/courier-react": patch
+---
+
+Fix an issue where custom React components were missing their event handlers.
+Fix an issue where custom React components may not be rendered.

--- a/@trycourier/courier-react-17/src/__tests__/integration/courier-inbox.test.tsx
+++ b/@trycourier/courier-react-17/src/__tests__/integration/courier-inbox.test.tsx
@@ -1,7 +1,8 @@
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import { CourierInbox } from '../../components/courier-inbox';
 import { CourierInbox as CourierInboxElement } from '@trycourier/courier-ui-inbox';
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 describe('CourierInbox', () => {
   beforeEach(() => {
@@ -28,6 +29,31 @@ describe('CourierInbox', () => {
 
       // We can access the CourierInbox Web Component's properties
       expect((ref as React.RefObject<CourierInboxElement | null>).current?.currentFeed).toBe('inbox');
+    });
+  });
+
+  describe('renderHeader', () => {
+    it('should set a custom header and including event handlers', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const clickHandler = jest.fn();
+      const CustomHeader = () => <div id="my-header" onClick={clickHandler}>Custom Header</div>;
+
+      await act(async () => {
+        ReactDOM.render(<CourierInbox renderHeader={CustomHeader} />, container);
+      });
+
+      const customHeader = container.querySelector('#my-header') as HTMLElement;
+
+      expect(customHeader).toBeDefined();
+      expect(customHeader?.textContent).toBe("Custom Header");
+
+      // Test that the click handler works
+      if (customHeader) {
+        customHeader.click();
+        expect(clickHandler).toHaveBeenCalled();
+      }
     });
   });
 });

--- a/@trycourier/courier-react-17/src/utils/render.tsx
+++ b/@trycourier/courier-react-17/src/utils/render.tsx
@@ -11,12 +11,5 @@ export function reactNodeToHTMLElement(node: ReactNode): HTMLElement {
 
   render(node, container);
 
-  const element = container.firstElementChild;
-  if (!(element instanceof HTMLElement)) {
-    throw new Error(
-      'reactNodeToHTMLElement must return a single JSX element that renders to an HTMLElement (e.g., <div>)'
-    );
-  }
-
-  return element;
+  return container;
 }

--- a/@trycourier/courier-react-components/src/components/courier-inbox-component.tsx
+++ b/@trycourier/courier-react-components/src/components/courier-inbox-component.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, forwardRef, ReactNode, useContext } from "react";
+import { useRef, useEffect, forwardRef, ReactNode, useContext, useState } from "react";
 import { CourierInboxListItemActionFactoryProps, CourierInboxListItemFactoryProps, CourierInboxTheme, CourierInbox as CourierInboxElement, CourierInboxHeaderFactoryProps, CourierInboxStateEmptyFactoryProps, CourierInboxStateLoadingFactoryProps, CourierInboxStateErrorFactoryProps, CourierInboxPaginationItemFactoryProps, CourierInboxFeedType } from "@trycourier/courier-ui-inbox";
 import { CourierComponentThemeMode } from "@trycourier/courier-ui-core";
 import { CourierClientComponent } from "./courier-client-component";
@@ -56,6 +56,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
 
   // Element ref for use in effects, updated by handleRef.
   const inboxRef = useRef<CourierInboxElement | null>(null);
+  const [elementReady, setElementReady] = useState(false);
 
   // Callback ref passed to rendered component, used to propagate the DOM element's ref to the parent component.
   // We use a callback ref (rather than a React.RefObject) since we want the parent ref to be up-to-date with
@@ -76,6 +77,9 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
 
     // Store the element for use in effects
     inboxRef.current = el;
+
+    // Update element ready state
+    setElementReady(!!el);
   }
 
   // Helper to get the current element
@@ -88,21 +92,21 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
     const inbox = getEl();
     if (!inbox) return;
     inbox.onMessageClick(props.onMessageClick);
-  }, [props.onMessageClick]);
+  }, [props.onMessageClick, elementReady]);
 
   // Handle message action click
   useEffect(() => {
     const inbox = getEl();
     if (!inbox) return;
     inbox.onMessageActionClick(props.onMessageActionClick);
-  }, [props.onMessageActionClick]);
+  }, [props.onMessageActionClick, elementReady]);
 
   // Handle message long press
   useEffect(() => {
     const inbox = getEl();
     if (!inbox) return;
     inbox.onMessageLongPress(props.onMessageLongPress);
-  }, [props.onMessageLongPress]);
+  }, [props.onMessageLongPress, elementReady]);
 
   // Render header
   useEffect(() => {
@@ -114,7 +118,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
         return render(reactNode);
       });
     });
-  }, [props.renderHeader]);
+  }, [props.renderHeader, elementReady]);
 
   // Render list item
   useEffect(() => {
@@ -126,7 +130,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
         return render(reactNode);
       });
     });
-  }, [props.renderListItem]);
+  }, [props.renderListItem, elementReady]);
 
   // Render empty state
   useEffect(() => {
@@ -138,7 +142,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
         return render(reactNode);
       });
     });
-  }, [props.renderEmptyState]);
+  }, [props.renderEmptyState, elementReady]);
 
   // Render loading state
   useEffect(() => {
@@ -150,7 +154,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
         return render(reactNode);
       });
     });
-  }, [props.renderLoadingState]);
+  }, [props.renderLoadingState, elementReady]);
 
   // Render error state
   useEffect(() => {
@@ -162,7 +166,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
         return render(reactNode);
       });
     });
-  }, [props.renderErrorState]);
+  }, [props.renderErrorState, elementReady]);
 
   // Render pagination item
   useEffect(() => {
@@ -174,7 +178,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
         return render(reactNode);
       });
     });
-  }, [props.renderPaginationItem]);
+  }, [props.renderPaginationItem, elementReady]);
 
   // Set feed type
   useEffect(() => {
@@ -183,7 +187,7 @@ export const CourierInboxComponent = forwardRef<CourierInboxElement, CourierInbo
     queueMicrotask(() => {
       inbox.setFeedType(props.feedType || 'inbox');
     });
-  }, [props.feedType]);
+  }, [props.feedType, elementReady]);
 
   const children = (
     /* @ts-ignore */

--- a/@trycourier/courier-react-components/src/components/courier-inbox-popup-menu-component.tsx
+++ b/@trycourier/courier-react-components/src/components/courier-inbox-popup-menu-component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, forwardRef, ReactNode, useContext } from 'react';
+import { useEffect, useRef, forwardRef, ReactNode, useContext, useState } from 'react';
 import {
   CourierInboxFeedType,
   CourierInboxHeaderFactoryProps,
@@ -91,6 +91,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
 
     // Element ref for use in effects, updated by handleRef.
     const inboxRef = useRef<CourierInboxPopupMenuElement | null>(null);
+    const [elementReady, setElementReady] = useState(false);
 
     // Callback ref passed to rendered component, used to propagate the DOM element's ref to the parent component.
     // We use a callback ref (rather than a React.RefObject) since we want the parent ref to be up-to-date with
@@ -108,6 +109,9 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
 
       // Store the element for use in effects
       inboxRef.current = el;
+
+      // Update element ready state
+      setElementReady(!!el);
     }
 
     // Helper to get the current element
@@ -128,28 +132,28 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           menu.setFeedType?.(props.feedType ?? 'inbox');
         });
       }
-    }, [props.feedType]);
+    }, [props.feedType, elementReady]);
 
     // Handle message click
     useEffect(() => {
       const menu = getEl();
       if (!menu) return;
       menu.onMessageClick(props.onMessageClick);
-    }, [props.onMessageClick]);
+    }, [props.onMessageClick, elementReady]);
 
     // Handle message action click
     useEffect(() => {
       const menu = getEl();
       if (!menu) return;
       menu.onMessageActionClick(props.onMessageActionClick);
-    }, [props.onMessageActionClick]);
+    }, [props.onMessageActionClick, elementReady]);
 
     // Handle message long press
     useEffect(() => {
       const menu = getEl();
       if (!menu) return;
       menu.onMessageLongPress(props.onMessageLongPress);
-    }, [props.onMessageLongPress]);
+    }, [props.onMessageLongPress, elementReady]);
 
     // Render header
     useEffect(() => {
@@ -161,7 +165,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           return render(reactNode);
         });
       });
-    }, [props.renderHeader]);
+    }, [props.renderHeader, elementReady]);
 
     // Render list item
     useEffect(() => {
@@ -173,7 +177,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           return render(reactNode);
         });
       });
-    }, [props.renderListItem]);
+    }, [props.renderListItem, elementReady]);
 
     // Render empty state
     useEffect(() => {
@@ -185,7 +189,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           return render(reactNode);
         });
       });
-    }, [props.renderEmptyState]);
+    }, [props.renderEmptyState, elementReady]);
 
     // Render loading state
     useEffect(() => {
@@ -197,7 +201,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           return render(reactNode);
         });
       });
-    }, [props.renderLoadingState]);
+    }, [props.renderLoadingState, elementReady]);
 
     // Render error state
     useEffect(() => {
@@ -209,7 +213,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           return render(reactNode);
         });
       });
-    }, [props.renderErrorState]);
+    }, [props.renderErrorState, elementReady]);
 
     // Render pagination item
     useEffect(() => {
@@ -221,7 +225,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           return render(reactNode);
         });
       });
-    }, [props.renderPaginationItem]);
+    }, [props.renderPaginationItem, elementReady]);
 
     // Render menu button
     useEffect(() => {
@@ -233,7 +237,7 @@ export const CourierInboxPopupMenuComponent = forwardRef<CourierInboxPopupMenuEl
           return render(reactNode);
         });
       });
-    }, [props.renderMenuButton]);
+    }, [props.renderMenuButton, elementReady]);
 
     const children = (
       /* @ts-ignore */

--- a/@trycourier/courier-react/src/__tests__/integration/courier-inbox.test.tsx
+++ b/@trycourier/courier-react/src/__tests__/integration/courier-inbox.test.tsx
@@ -1,7 +1,8 @@
 import { render } from '@testing-library/react';
 import { CourierInbox } from '../../components/courier-inbox';
 import { CourierInbox as CourierInboxElement } from '@trycourier/courier-ui-inbox';
-import React from 'react';
+import React, { act } from 'react';
+import { createRoot } from "react-dom/client";
 
 describe('CourierInbox', () => {
   beforeEach(() => {
@@ -28,6 +29,31 @@ describe('CourierInbox', () => {
 
       // We can access the CourierInbox Web Component's properties
       expect((ref as React.RefObject<CourierInboxElement | null>).current?.currentFeed).toBe('inbox');
+    });
+  });
+
+  describe('renderHeader', () => {
+    it('should set a custom header and including event handlers', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const clickHandler = jest.fn();
+      const CustomHeader = () => <div id="my-header" onClick={clickHandler}>Custom Header</div>;
+
+      await act(async () => {
+        createRoot(container).render(<CourierInbox renderHeader={CustomHeader} />);
+      });
+
+      const customHeader = container.querySelector('#my-header') as HTMLElement;
+
+      expect(customHeader).toBeDefined();
+      expect(customHeader?.textContent).toBe("Custom Header");
+
+      // Test that the click handler works
+      if (customHeader) {
+        customHeader.click();
+        expect(clickHandler).toHaveBeenCalled();
+      }
     });
   });
 });

--- a/@trycourier/courier-react/src/utils/render.tsx
+++ b/@trycourier/courier-react/src/utils/render.tsx
@@ -17,13 +17,7 @@ export function reactNodeToHTMLElement(node: ReactNode): HTMLElement {
     root.render(node);
   });
 
-  // Wait until React mounts the content synchronously
-  const element = container.firstElementChild;
-  if (!(element instanceof HTMLElement)) {
-    throw new Error(
-      'renderListItem must return a single JSX element that renders to an HTMLElement (e.g., <div>)'
-    );
-  }
-
-  return element;
+  // Return the container to preserve React's event handling
+  // The container maintains the React root and event delegation
+  return container;
 }


### PR DESCRIPTION
Returning the container into which the custom component is rendered (rather than its child) preserves event handlers added by React. Container has the event handlers, not the element itself.

Additionally, maintaining state for when `ref` is set in the `CourierInbox` component makes sure `setHeader` etc. are called on defined refs rather than `null`. 

Internal:
 * https://linear.app/trycourier/issue/C-15162
 * https://linear.app/trycourier/issue/C-15165