### PR TITLE
Move common theme components and manager to courier-ui-core.

### DIFF
--- a/.changeset/huge-worlds-remain.md
+++ b/.changeset/huge-worlds-remain.md
@@ -1,0 +1,9 @@
+---
+"@trycourier/courier-ui-inbox": patch
+"@trycourier/courier-ui-core": patch
+"@trycourier/courier-react": patch
+"@trycourier/courier-react-17": patch
+"@trycourier/courier-react-components": patch
+---
+
+Reorganize theme management to improve maintainability.

--- a/@trycourier/courier-ui-core/src/index.ts
+++ b/@trycourier/courier-ui-core/src/index.ts
@@ -21,6 +21,10 @@ export * from './utils/theme';
 export * from './utils/courier-colors';
 export * from './utils/registeration';
 
+// Export theme management
+export * from './managers/courier-theme-manager';
+export * from './types/common-theme-types';
+
 // Register core UI components
 registerElement(CourierButton);
 registerElement(CourierIcon);

--- a/@trycourier/courier-ui-core/src/managers/courier-theme-manager.ts
+++ b/@trycourier/courier-ui-core/src/managers/courier-theme-manager.ts
@@ -135,8 +135,8 @@ export abstract class CourierThemeManager<TTheme> {
 
   /**
    * Subscribe to theme changes
-   * @param {Function} callback - Function to run when the theme changes
-   * @returns {CourierThemeSubscription} - Object with unsubscribe method to stop listening
+   * @param callback - Function to run when the theme changes
+   * @returns - Object with unsubscribe method to stop listening
    */
   public subscribe(callback: (theme: TTheme) => void): CourierThemeSubscription<TTheme> {
     const controller = new AbortController();

--- a/@trycourier/courier-ui-core/src/managers/courier-theme-manager.ts
+++ b/@trycourier/courier-ui-core/src/managers/courier-theme-manager.ts
@@ -1,0 +1,173 @@
+import { CourierComponentThemeMode, SystemThemeMode, addSystemThemeModeListener, getSystemThemeMode } from "../utils/system-theme-mode";
+
+export interface CourierThemeSubscription<TTheme> {
+  manager: CourierThemeManager<TTheme>;
+  unsubscribe: () => void;
+}
+
+/**
+ * Abstract base class for theme management in Courier UI packages.
+ *
+ * This class provides:
+ * - Light/dark theme switching
+ * - System theme detection and auto-switching
+ * - Theme subscription/notification system
+ * - User mode override (light, dark, or system)
+ *
+ * Subclasses must implement:
+ * - getDefaultLightTheme(): return the default light theme
+ * - getDefaultDarkTheme(): return the default dark theme
+ * - mergeTheme(): merge user theme with defaults
+ */
+export abstract class CourierThemeManager<TTheme> {
+
+  // Abstract properties and methods that subclasses must implement
+  protected abstract readonly THEME_CHANGE_EVENT: string;
+  protected abstract getDefaultLightTheme(): TTheme;
+  protected abstract getDefaultDarkTheme(): TTheme;
+  protected abstract mergeTheme(mode: SystemThemeMode, theme: TTheme): TTheme;
+
+  // State (protected so subclasses can access if needed)
+  protected _theme: TTheme;
+  protected _lightTheme!: TTheme;
+  protected _darkTheme!: TTheme;
+  protected _target: EventTarget;
+  protected _subscriptions: CourierThemeSubscription<TTheme>[] = [];
+
+  // System theme
+  protected _userMode: CourierComponentThemeMode;
+  protected _systemMode: SystemThemeMode;
+  protected _systemThemeCleanup: (() => void) | undefined;
+
+  constructor(initialTheme: TTheme) {
+    this._theme = initialTheme;
+    this._target = new EventTarget();
+    this._userMode = 'system' as CourierComponentThemeMode;
+
+    // Get the initial system theme
+    this._systemMode = getSystemThemeMode();
+    this.setLightTheme(this.getDefaultLightTheme());
+    this.setDarkTheme(this.getDefaultDarkTheme());
+
+    // Set up system theme listener
+    this._systemThemeCleanup = addSystemThemeModeListener((mode: SystemThemeMode) => {
+      this._systemMode = mode;
+      this.updateTheme();
+    });
+  }
+
+  /**
+   * Set the light theme
+   */
+  public setLightTheme(theme: TTheme) {
+    this._lightTheme = theme;
+    if (this._systemMode === 'light') {
+      this.updateTheme();
+    }
+  }
+
+  /**
+   * Set the dark theme
+   */
+  public setDarkTheme(theme: TTheme) {
+    this._darkTheme = theme;
+    if (this._systemMode === 'dark') {
+      this.updateTheme();
+    }
+  }
+
+  /**
+   * Get the current system theme
+   */
+  public get currentSystemTheme(): SystemThemeMode {
+    return this._systemMode;
+  }
+
+  /**
+   * Get the current theme
+   */
+  public getTheme(): TTheme {
+    return this._theme;
+  }
+
+  /**
+   * Update the theme based on current mode
+   */
+  protected updateTheme() {
+    // Use the user mode or fallback to the system mode
+    const mode = this._userMode === 'system' ? this._systemMode : this._userMode;
+
+    // Get the theme
+    const theme = mode === 'light' ? this._lightTheme : this._darkTheme;
+
+    // Merge the theme
+    const mergedTheme = this.mergeTheme(mode, theme);
+
+    // Set the theme
+    this.setTheme(mergedTheme);
+  }
+
+  /**
+   * Set the theme and notify all listeners
+   */
+  private setTheme(theme: TTheme) {
+    if (theme === this._theme) return;
+    this._theme = theme;
+    this._target.dispatchEvent(new CustomEvent(this.THEME_CHANGE_EVENT, {
+      detail: { theme }
+    }));
+  }
+
+  /**
+   * Set the mode and notify all listeners
+   */
+  public setMode(mode: CourierComponentThemeMode) {
+    this._userMode = mode;
+    this.updateTheme();
+  }
+
+  /**
+   * Get the current mode
+   */
+  public get mode(): CourierComponentThemeMode {
+    return this._userMode;
+  }
+
+  /**
+   * Subscribe to theme changes
+   * @param {Function} callback - Function to run when the theme changes
+   * @returns {CourierThemeSubscription} - Object with unsubscribe method to stop listening
+   */
+  public subscribe(callback: (theme: TTheme) => void): CourierThemeSubscription<TTheme> {
+    const controller = new AbortController();
+    this._target.addEventListener(this.THEME_CHANGE_EVENT, ((e: Event) => {
+      callback((e as CustomEvent<{ theme: TTheme }>).detail.theme);
+    }) as EventListener, { signal: controller.signal });
+
+    const subscription: CourierThemeSubscription<TTheme> = {
+      manager: this,
+      unsubscribe: () => {
+        controller.abort();
+        const index = this._subscriptions.indexOf(subscription);
+        if (index > -1) {
+          this._subscriptions.splice(index, 1);
+        }
+      }
+    };
+
+    this._subscriptions.push(subscription);
+    return subscription;
+  }
+
+  /**
+   * Clean up event listeners
+   */
+  public cleanup() {
+    if (this._systemThemeCleanup) {
+      this._systemThemeCleanup();
+    }
+    this._subscriptions.forEach(subscription => subscription.unsubscribe());
+    this._subscriptions = [];
+  }
+
+}

--- a/@trycourier/courier-ui-core/src/types/common-theme-types.ts
+++ b/@trycourier/courier-ui-core/src/types/common-theme-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Common theme types that can be shared across all Courier UI packages
+ */
+
+export type CourierFontTheme = {
+  family?: string;
+  weight?: string;
+  size?: string;
+  color?: string;
+}
+
+export type CourierIconTheme = {
+  color?: string;
+  svg?: string;
+}
+
+export type CourierButtonTheme = {
+  font?: CourierFontTheme;
+  text?: string;
+  shadow?: string;
+  border?: string;
+  borderRadius?: string;
+  backgroundColor?: string;
+  hoverBackgroundColor?: string;
+  activeBackgroundColor?: string;
+}
+
+export type CourierIconButtonTheme = {
+  icon?: CourierIconTheme;
+  backgroundColor?: string;
+  hoverBackgroundColor?: string;
+  activeBackgroundColor?: string;
+}

--- a/@trycourier/courier-ui-inbox/src/types/courier-inbox-theme-manager.ts
+++ b/@trycourier/courier-ui-inbox/src/types/courier-inbox-theme-manager.ts
@@ -41,8 +41,8 @@ export class CourierInboxThemeManager extends CourierThemeManager<CourierInboxTh
 
   /**
    * Subscribe to inbox theme changes
-   * @param {Function} callback - Function to run when the theme changes
-   * @returns {CourierInboxThemeSubscription} - Object with unsubscribe method to stop listening
+   * @param callback - Function to run when the theme changes
+   * @returns Object with unsubscribe method to stop listening
    */
   public subscribe(callback: (theme: CourierInboxTheme) => void): CourierInboxThemeSubscription {
     const baseSubscription = super.subscribe(callback);

--- a/@trycourier/courier-ui-inbox/src/types/courier-inbox-theme-manager.ts
+++ b/@trycourier/courier-ui-inbox/src/types/courier-inbox-theme-manager.ts
@@ -1,149 +1,55 @@
-import { CourierComponentThemeMode, SystemThemeMode, addSystemThemeModeListener, getSystemThemeMode } from "@trycourier/courier-ui-core";
+import { CourierThemeManager, CourierThemeSubscription, SystemThemeMode } from "@trycourier/courier-ui-core";
 import { CourierInboxTheme, defaultDarkTheme, defaultLightTheme, mergeTheme } from "./courier-inbox-theme";
 
-export interface CourierInboxThemeSubscription {
+export interface CourierInboxThemeSubscription extends CourierThemeSubscription<CourierInboxTheme> {
   manager: CourierInboxThemeManager;
-  unsubscribe: () => void;
 }
 
-export class CourierInboxThemeManager {
+/**
+ * Inbox-specific theme manager that extends the abstract CourierThemeManager.
+ * Provides inbox theme management with light/dark mode support.
+ */
+export class CourierInboxThemeManager extends CourierThemeManager<CourierInboxTheme> {
 
-  // Event IDs
-  private readonly THEME_CHANGE_EVENT: string = 'courier_inbox_theme_change';
-
-  // State
-  private _theme: CourierInboxTheme;
-  private _lightTheme: CourierInboxTheme = defaultLightTheme;
-  private _darkTheme: CourierInboxTheme = defaultDarkTheme;
-  private _target: EventTarget;
-  private _subscriptions: CourierInboxThemeSubscription[] = [];
-
-  // System theme
-  private _userMode: CourierComponentThemeMode;
-  private _systemMode: SystemThemeMode;
-  private _systemThemeCleanup: (() => void) | undefined;
-
-  public setLightTheme(theme: CourierInboxTheme) {
-    this._lightTheme = theme;
-    if (this._systemMode === 'light') {
-      this.updateTheme();
-    }
-  }
-
-  public setDarkTheme(theme: CourierInboxTheme) {
-    this._darkTheme = theme;
-    if (this._systemMode === 'dark') {
-      this.updateTheme();
-    }
-  }
+  // Event ID for inbox theme changes
+  protected readonly THEME_CHANGE_EVENT: string = 'courier_inbox_theme_change';
 
   constructor(initialTheme: CourierInboxTheme) {
-    this._theme = initialTheme;
-    this._target = new EventTarget();
-    this._userMode = 'system' as CourierComponentThemeMode;
-
-    // Get the initial system theme
-    this._systemMode = getSystemThemeMode();
-    this.setLightTheme(defaultLightTheme);
-    this.setDarkTheme(defaultDarkTheme);
-
-    // Set up system theme listener
-    this._systemThemeCleanup = addSystemThemeModeListener((mode: SystemThemeMode) => {
-      this._systemMode = mode;
-      this.updateTheme();
-    });
+    super(initialTheme);
   }
 
   /**
-   * Get the current system theme
+   * Get the default light theme for inbox
    */
-  public get currentSystemTheme(): SystemThemeMode {
-    return this._systemMode;
+  protected getDefaultLightTheme(): CourierInboxTheme {
+    return defaultLightTheme;
   }
 
   /**
-   * Get the current theme
+   * Get the default dark theme for inbox
    */
-  public getTheme() {
-    return this._theme;
+  protected getDefaultDarkTheme(): CourierInboxTheme {
+    return defaultDarkTheme;
   }
 
   /**
-   * Update the theme
+   * Merge the inbox theme with defaults
    */
-  private updateTheme() {
-
-    // Use the user mode or fallback to the system mode
-    const mode = this._userMode === 'system' ? this._systemMode : this._userMode;
-
-    // Get the theme  
-    const theme = mode === 'light' ? this._lightTheme : this._darkTheme;
-
-    // Merge the theme
-    const mergedTheme = mergeTheme(mode, theme);
-
-    // Set the theme
-    this.setTheme(mergedTheme);
+  protected mergeTheme(mode: SystemThemeMode, theme: CourierInboxTheme): CourierInboxTheme {
+    return mergeTheme(mode, theme);
   }
 
   /**
-   * Set the theme and notify all listeners
-   */
-  private setTheme(theme: CourierInboxTheme) {
-    if (theme === this._theme) return;
-    this._theme = theme;
-    this._target.dispatchEvent(new CustomEvent(this.THEME_CHANGE_EVENT, {
-      detail: { theme }
-    }));
-  }
-
-  /**
-   * Set the mode and notify all listeners
-   */
-  public setMode(mode: CourierComponentThemeMode) {
-    this._userMode = mode;
-    this.updateTheme();
-  }
-
-  public get mode(): CourierComponentThemeMode {
-    return this._userMode;
-  }
-
-  /**
-   * Subscribe to theme changes
+   * Subscribe to inbox theme changes
    * @param {Function} callback - Function to run when the theme changes
-   * @returns {CourierInboxThemeSubscription} - Object with remove method to stop listening
+   * @returns {CourierInboxThemeSubscription} - Object with unsubscribe method to stop listening
    */
-  subscribe(callback: (theme: CourierInboxTheme) => void): CourierInboxThemeSubscription {
-    const controller = new AbortController();
-    this._target.addEventListener(this.THEME_CHANGE_EVENT, ((e: Event) => {
-      callback((e as CustomEvent<{ theme: CourierInboxTheme }>).detail.theme);
-    }) as EventListener, { signal: controller.signal });
-
-    const subscription: CourierInboxThemeSubscription = {
-      manager: this,
-      unsubscribe: () => {
-        controller.abort();
-        const index = this._subscriptions.indexOf(subscription);
-        if (index > -1) {
-          this._subscriptions.splice(index, 1);
-        }
-      }
+  public subscribe(callback: (theme: CourierInboxTheme) => void): CourierInboxThemeSubscription {
+    const baseSubscription = super.subscribe(callback);
+    return {
+      ...baseSubscription,
+      manager: this
     };
-
-    this._subscriptions.push(subscription);
-    return subscription;
-  }
-
-  /**
-   * Clean up event listeners
-   */
-  public cleanup() {
-    if (this._systemThemeCleanup) {
-      this._systemThemeCleanup();
-    }
-    this._subscriptions.forEach(subscription => subscription.unsubscribe());
-    this._subscriptions = [];
   }
 
 }

--- a/@trycourier/courier-ui-inbox/src/types/courier-inbox-theme.ts
+++ b/@trycourier/courier-ui-inbox/src/types/courier-inbox-theme.ts
@@ -1,16 +1,10 @@
-import { CourierColors, CourierIconSVGs, SystemThemeMode } from "@trycourier/courier-ui-core";
+import { CourierColors, CourierIconSVGs, SystemThemeMode, CourierFontTheme, CourierIconTheme, CourierButtonTheme, CourierIconButtonTheme } from "@trycourier/courier-ui-core";
 
-export type CourierInboxFontTheme = {
-  family?: string;
-  weight?: string;
-  size?: string;
-  color?: string;
-}
-
-export type CourierInboxIconTheme = {
-  color?: string;
-  svg?: string;
-}
+// Re-export common types from core for convenience
+export type CourierInboxFontTheme = CourierFontTheme;
+export type CourierInboxIconTheme = CourierIconTheme;
+export type CourierInboxButtonTheme = CourierButtonTheme;
+export type CourierInboxIconButtonTheme = CourierIconButtonTheme;
 
 export type CourierInboxFilterItemTheme = {
   icon?: CourierInboxIconTheme;
@@ -29,24 +23,6 @@ export type CourierInboxUnreadCountIndicatorTheme = {
   backgroundColor?: string;
   borderRadius?: string;
   padding?: string;
-}
-
-export type CourierInboxIconButtonTheme = {
-  icon?: CourierInboxIconTheme;
-  backgroundColor?: string;
-  hoverBackgroundColor?: string;
-  activeBackgroundColor?: string;
-}
-
-export type CourierInboxButtonTheme = {
-  font?: CourierInboxFontTheme;
-  text?: string;
-  shadow?: string;
-  border?: string;
-  borderRadius?: string;
-  backgroundColor?: string;
-  hoverBackgroundColor?: string;
-  activeBackgroundColor?: string;
 }
 
 export type CourierInboxMenuButtonTheme = CourierInboxIconButtonTheme & {

--- a/api/courier-ui-core.api.md
+++ b/api/courier-ui-core.api.md
@@ -70,6 +70,20 @@ export type CourierButtonProps = {
     onClick?: () => void;
 };
 
+// Warning: (ae-missing-release-tag) "CourierButtonTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CourierButtonTheme = {
+    font?: CourierFontTheme;
+    text?: string;
+    shadow?: string;
+    border?: string;
+    borderRadius?: string;
+    backgroundColor?: string;
+    hoverBackgroundColor?: string;
+    activeBackgroundColor?: string;
+};
+
 // Warning: (ae-missing-release-tag) "CourierButtonVariant" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -150,6 +164,16 @@ export class CourierFactoryElement extends CourierSystemThemeElement {
     defaultElement(): HTMLElement;
 }
 
+// Warning: (ae-missing-release-tag) "CourierFontTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export type CourierFontTheme = {
+    family?: string;
+    weight?: string;
+    size?: string;
+    color?: string;
+};
+
 // Warning: (ae-missing-release-tag) "CourierIcon" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -182,6 +206,16 @@ export class CourierIconButton extends CourierBaseElement {
     updateIconSVG(svg: string): void;
 }
 
+// Warning: (ae-missing-release-tag) "CourierIconButtonTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CourierIconButtonTheme = {
+    icon?: CourierIconTheme;
+    backgroundColor?: string;
+    hoverBackgroundColor?: string;
+    activeBackgroundColor?: string;
+};
+
 // Warning: (ae-missing-release-tag) "CourierIconSVGs" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
@@ -197,6 +231,14 @@ export const CourierIconSVGs: {
     archiveRead: string;
     unread: string;
     unarchive: string;
+};
+
+// Warning: (ae-missing-release-tag) "CourierIconTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export type CourierIconTheme = {
+    color?: string;
+    svg?: string;
 };
 
 // Warning: (ae-missing-release-tag) "CourierInfoState" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -256,6 +298,56 @@ export class CourierSystemThemeElement extends CourierBaseElement {
     protected onComponentUnmounted(): void;
     // (undocumented)
     protected onSystemThemeChange(_: SystemThemeMode): void;
+}
+
+// Warning: (ae-missing-release-tag) "CourierThemeManager" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export abstract class CourierThemeManager<TTheme> {
+    constructor(initialTheme: TTheme);
+    cleanup(): void;
+    get currentSystemTheme(): SystemThemeMode;
+    // (undocumented)
+    protected _darkTheme: TTheme;
+    // (undocumented)
+    protected abstract getDefaultDarkTheme(): TTheme;
+    // (undocumented)
+    protected abstract getDefaultLightTheme(): TTheme;
+    getTheme(): TTheme;
+    // (undocumented)
+    protected _lightTheme: TTheme;
+    // (undocumented)
+    protected abstract mergeTheme(mode: SystemThemeMode, theme: TTheme): TTheme;
+    get mode(): CourierComponentThemeMode;
+    setDarkTheme(theme: TTheme): void;
+    setLightTheme(theme: TTheme): void;
+    setMode(mode: CourierComponentThemeMode): void;
+    subscribe(callback: (theme: TTheme) => void): CourierThemeSubscription<TTheme>;
+    // (undocumented)
+    protected _subscriptions: CourierThemeSubscription<TTheme>[];
+    // (undocumented)
+    protected _systemMode: SystemThemeMode;
+    // (undocumented)
+    protected _systemThemeCleanup: (() => void) | undefined;
+    // (undocumented)
+    protected _target: EventTarget;
+    // (undocumented)
+    protected _theme: TTheme;
+    // (undocumented)
+    protected abstract readonly THEME_CHANGE_EVENT: string;
+    protected updateTheme(): void;
+    // (undocumented)
+    protected _userMode: CourierComponentThemeMode;
+}
+
+// Warning: (ae-missing-release-tag) "CourierThemeSubscription" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public (undocumented)
+export interface CourierThemeSubscription<TTheme> {
+    // (undocumented)
+    manager: CourierThemeManager<TTheme>;
+    // (undocumented)
+    unsubscribe: () => void;
 }
 
 // Warning: (ae-missing-release-tag) "getSystemThemeMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)

--- a/api/courier-ui-inbox.api.md
+++ b/api/courier-ui-inbox.api.md
@@ -8,13 +8,19 @@ import { Courier } from '@trycourier/courier-js';
 import { CourierApiUrls } from '@trycourier/courier-js';
 import { CourierBaseElement } from '@trycourier/courier-ui-core';
 import { CourierBrand } from '@trycourier/courier-js';
+import { CourierButtonTheme } from '@trycourier/courier-ui-core';
 import { CourierClientOptions } from '@trycourier/courier-js';
 import { CourierComponentThemeMode } from '@trycourier/courier-ui-core';
 import { CourierDevice } from '@trycourier/courier-js';
 import { CourierFactoryElement } from '@trycourier/courier-ui-core';
+import { CourierFontTheme } from '@trycourier/courier-ui-core';
 import { CourierGetInboxMessageResponse } from '@trycourier/courier-js';
 import { CourierGetInboxMessagesResponse } from '@trycourier/courier-js';
+import { CourierIconButtonTheme } from '@trycourier/courier-ui-core';
+import { CourierIconTheme } from '@trycourier/courier-ui-core';
 import { CourierProps } from '@trycourier/courier-js';
+import { CourierThemeManager } from '@trycourier/courier-ui-core';
+import { CourierThemeSubscription } from '@trycourier/courier-ui-core';
 import { CourierToken } from '@trycourier/courier-js';
 import { CourierUserPreferences } from '@trycourier/courier-js';
 import { CourierUserPreferencesChannel } from '@trycourier/courier-js';
@@ -112,16 +118,7 @@ export class CourierInbox extends CourierBaseElement {
 // Warning: (ae-missing-release-tag) "CourierInboxButtonTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type CourierInboxButtonTheme = {
-    font?: CourierInboxFontTheme;
-    text?: string;
-    shadow?: string;
-    border?: string;
-    borderRadius?: string;
-    backgroundColor?: string;
-    hoverBackgroundColor?: string;
-    activeBackgroundColor?: string;
-};
+export type CourierInboxButtonTheme = CourierButtonTheme;
 
 // Warning: (ae-missing-release-tag) "CourierInboxDatastore" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -239,12 +236,7 @@ export type CourierInboxFilterItemTheme = {
 // Warning: (ae-missing-release-tag) "CourierInboxFontTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type CourierInboxFontTheme = {
-    family?: string;
-    weight?: string;
-    size?: string;
-    color?: string;
-};
+export type CourierInboxFontTheme = CourierFontTheme;
 
 // Warning: (ae-missing-release-tag) "CourierInboxHeader" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -289,20 +281,12 @@ export type CourierInboxHeaderMenuItemId = CourierInboxFeedType | 'markAllRead' 
 // Warning: (ae-missing-release-tag) "CourierInboxIconButtonTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type CourierInboxIconButtonTheme = {
-    icon?: CourierInboxIconTheme;
-    backgroundColor?: string;
-    hoverBackgroundColor?: string;
-    activeBackgroundColor?: string;
-};
+export type CourierInboxIconButtonTheme = CourierIconButtonTheme;
 
 // Warning: (ae-missing-release-tag) "CourierInboxIconTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export type CourierInboxIconTheme = {
-    color?: string;
-    svg?: string;
-};
+export type CourierInboxIconTheme = CourierIconTheme;
 
 // Warning: (ae-missing-release-tag) "CourierInboxInfoStateTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -578,33 +562,23 @@ export type CourierInboxTheme = {
 
 // Warning: (ae-missing-release-tag) "CourierInboxThemeManager" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
-// @public (undocumented)
-export class CourierInboxThemeManager {
+// @public
+export class CourierInboxThemeManager extends CourierThemeManager<CourierInboxTheme> {
     constructor(initialTheme: CourierInboxTheme);
-    cleanup(): void;
-    get currentSystemTheme(): SystemThemeMode;
-    getTheme(): CourierInboxTheme;
-    // (undocumented)
-    get mode(): CourierComponentThemeMode;
-    // (undocumented)
-    setDarkTheme(theme: CourierInboxTheme): void;
-    // (undocumented)
-    setLightTheme(theme: CourierInboxTheme): void;
-    setMode(mode: CourierComponentThemeMode): void;
-    // Warning: (tsdoc-param-tag-with-invalid-type) The @param block should not include a JSDoc-style '{type}'
-    // Warning: (tsdoc-escape-right-brace) The "}" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag
-    // Warning: (tsdoc-malformed-inline-tag) Expecting a TSDoc tag starting with "{@"
+    protected getDefaultDarkTheme(): CourierInboxTheme;
+    protected getDefaultLightTheme(): CourierInboxTheme;
+    protected mergeTheme(mode: SystemThemeMode, theme: CourierInboxTheme): CourierInboxTheme;
     subscribe(callback: (theme: CourierInboxTheme) => void): CourierInboxThemeSubscription;
+    // (undocumented)
+    protected readonly THEME_CHANGE_EVENT: string;
 }
 
 // Warning: (ae-missing-release-tag) "CourierInboxThemeSubscription" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
-export interface CourierInboxThemeSubscription {
+export interface CourierInboxThemeSubscription extends CourierThemeSubscription<CourierInboxTheme> {
     // (undocumented)
     manager: CourierInboxThemeManager;
-    // (undocumented)
-    unsubscribe: () => void;
 }
 
 // Warning: (ae-missing-release-tag) "CourierInboxUnreadCountIndicatorTheme" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)


### PR DESCRIPTION
Moves the common theme components from `courier-ui-inbox` to `courier-ui-core`, as well as most of the theme management code.

`CourierThemeManager` in `courier-ui-core` is now an abstract class that can be extended by Inbox or Toasts with their respective themes.