### PR TITLE
Notification preferences all option

### DIFF
--- a/@trycourier/courier-ui-inbox/src/components/__tests__/courier-inbox-list.clone-node.test.ts
+++ b/@trycourier/courier-ui-inbox/src/components/__tests__/courier-inbox-list.clone-node.test.ts
@@ -1,0 +1,67 @@
+import { InboxMessage } from "@trycourier/courier-js";
+import { CourierInboxList } from "../courier-inbox-list";
+import { defaultLightTheme } from "../../types/courier-inbox-theme";
+import { CourierInboxThemeManager } from "../../types/courier-inbox-theme-manager";
+
+class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin = "0px";
+  readonly thresholds: ReadonlyArray<number> = [];
+
+  disconnect(): void { }
+  observe(_target: Element): void { }
+  takeRecords(): IntersectionObserverEntry[] { return []; }
+  unobserve(_target: Element): void { }
+}
+
+describe("CourierInboxList cloneNode safety", () => {
+  beforeAll(() => {
+    (globalThis as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver = MockIntersectionObserver;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("does not throw when constructed without props", () => {
+    expect(() => {
+      Reflect.construct(CourierInboxList, []);
+    }).not.toThrow();
+  });
+
+  it("does not throw when deep-cloning a rendered list", () => {
+    const themeManager = new CourierInboxThemeManager(defaultLightTheme);
+    const list = new CourierInboxList({
+      themeManager,
+      canClickListItems: true,
+      canLongPressListItems: true,
+      onRefresh: () => { },
+      onPaginationTrigger: () => { },
+      onMessageClick: () => { },
+      onMessageActionClick: () => { },
+      onMessageLongPress: () => { },
+    });
+
+    const message: InboxMessage = {
+      messageId: crypto.randomUUID(),
+      title: "Hello",
+      body: "World",
+      preview: "World",
+      actions: [],
+      data: {},
+      created: "2026-01-01T00:00:00.000Z",
+    };
+
+    document.body.appendChild(list);
+    list.setDataSet({
+      id: "all_messages",
+      messages: [message],
+      unreadCount: 1,
+      canPaginate: true,
+      paginationCursor: "cursor-1",
+    });
+
+    expect(() => list.cloneNode(true)).not.toThrow();
+    themeManager.cleanup();
+  });
+});

--- a/@trycourier/courier-ui-inbox/src/components/__tests__/courier-inbox-list.clone-node.test.ts
+++ b/@trycourier/courier-ui-inbox/src/components/__tests__/courier-inbox-list.clone-node.test.ts
@@ -17,6 +17,20 @@ class MockIntersectionObserver implements IntersectionObserver {
 describe("CourierInboxList cloneNode safety", () => {
   beforeAll(() => {
     (globalThis as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver = MockIntersectionObserver;
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: jest.fn().mockImplementation((query: string): MediaQueryList => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => { },
+        removeListener: () => { },
+        addEventListener: () => { },
+        removeEventListener: () => { },
+        dispatchEvent: () => false,
+      })),
+    });
   });
 
   afterEach(() => {

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-list-item-menu.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-list-item-menu.ts
@@ -14,15 +14,23 @@ export class CourierInboxListItemMenu extends CourierBaseElement {
   }
 
   // State
-  private _theme: CourierInboxTheme;
+  private _theme!: CourierInboxTheme;
+  private _isConfigured = false;
   private _options: CourierInboxListItemActionMenuOption[] = [];
 
-  constructor(theme: CourierInboxTheme) {
+  constructor(theme?: CourierInboxTheme) {
     super();
+    if (!theme) {
+      return;
+    }
+    this._isConfigured = true;
     this._theme = theme;
   }
 
   onComponentMounted() {
+    if (!this._isConfigured) {
+      return;
+    }
     const menu = document.createElement('ul');
     menu.className = 'menu';
     this.appendChild(menu);
@@ -79,6 +87,9 @@ export class CourierInboxListItemMenu extends CourierBaseElement {
   }
 
   setOptions(options: CourierInboxListItemActionMenuOption[]) {
+    if (!this._isConfigured) {
+      return;
+    }
     this._options = options;
     this.renderMenu();
   }

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-list-item.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-list-item.ts
@@ -1,6 +1,6 @@
 import { InboxAction, InboxMessage } from "@trycourier/courier-js";
 import { CourierBaseElement, CourierButton, CourierIcon, CourierIconSVGs, registerElement } from "@trycourier/courier-ui-core";
-import { CourierInboxTheme } from "../types/courier-inbox-theme";
+import { CourierInboxTheme, defaultLightTheme } from "../types/courier-inbox-theme";
 import { getMessageTime } from "../utils/utils";
 import { CourierInboxListItemMenu, CourierInboxListItemActionMenuOption } from "./courier-inbox-list-item-menu";
 import { CourierInboxDatastore } from "../datastore/inbox-datastore";
@@ -15,8 +15,8 @@ export class CourierInboxListItem extends CourierBaseElement {
   }
 
   // State
-  private _themeManager: CourierInboxThemeManager;
-  private _theme: CourierInboxTheme;
+  private _themeManager?: CourierInboxThemeManager;
+  private _theme: CourierInboxTheme = defaultLightTheme;
   private _message: InboxMessage | null = null;
   private _isMobile: boolean = false;
   private _canClick: boolean = false;
@@ -44,8 +44,13 @@ export class CourierInboxListItem extends CourierBaseElement {
   private onItemActionClick: ((message: InboxMessage, action: InboxAction) => void) | null = null;
   private onItemVisible: ((message: InboxMessage) => void) | null = null;
 
-  constructor(themeManager: CourierInboxThemeManager, canClick: boolean, _canLongPress: boolean, listItemActions?: CourierInboxListItemAction[]) {
+  constructor(themeManager?: CourierInboxThemeManager, canClick = false, _canLongPress = false, listItemActions?: CourierInboxListItemAction[]) {
     super();
+
+    if (!themeManager) {
+      return;
+    }
+
     this._canClick = canClick;
     // this._canLongPress = canLongPress;
     this._themeManager = themeManager;
@@ -516,7 +521,7 @@ export class CourierInboxListItem extends CourierBaseElement {
       this._message.actions.forEach(action => {
         // Create the action element
         const actionButton = new CourierButton({
-          mode: this._themeManager.mode,
+          mode: this._themeManager?.mode ?? 'system',
           text: action.content,
           variant: 'secondary',
           backgroundColor: actionsTheme?.backgroundColor,

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-pagination-list-item.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-pagination-list-item.ts
@@ -9,7 +9,8 @@ export class CourierInboxPaginationListItem extends CourierBaseElement {
   }
 
   // State
-  private _theme: CourierInboxTheme;
+  private _theme!: CourierInboxTheme;
+  private _isConfigured = false;
 
   // Components
   private _style?: HTMLStyleElement;
@@ -18,16 +19,23 @@ export class CourierInboxPaginationListItem extends CourierBaseElement {
   private _customItem?: HTMLElement;
 
   // Handlers
-  private _onPaginationTrigger: () => void;
+  private _onPaginationTrigger: () => void = () => { };
 
-  constructor(props: { theme: CourierInboxTheme, customItem?: HTMLElement, onPaginationTrigger: () => void }) {
+  constructor(props?: { theme: CourierInboxTheme, customItem?: HTMLElement, onPaginationTrigger: () => void }) {
     super();
+    if (!props) {
+      return;
+    }
+    this._isConfigured = true;
     this._theme = props.theme;
     this._customItem = props.customItem;
     this._onPaginationTrigger = props.onPaginationTrigger;
   }
 
   onComponentMounted() {
+    if (!this._isConfigured) {
+      return;
+    }
 
     this._style = injectGlobalStyle(CourierInboxPaginationListItem.id, CourierInboxPaginationListItem.getStyles(this._theme));
 

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-skeleton-list-item.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-skeleton-list-item.ts
@@ -7,15 +7,23 @@ export class CourierInboxSkeletonListItem extends CourierBaseElement {
     return 'courier-inbox-skeleton-list-item';
   }
 
-  private _theme: CourierInboxTheme;
+  private _theme!: CourierInboxTheme;
+  private _isConfigured = false;
   private _style?: HTMLStyleElement;
 
-  constructor(theme: CourierInboxTheme) {
+  constructor(theme?: CourierInboxTheme) {
     super();
+    if (!theme) {
+      return;
+    }
+    this._isConfigured = true;
     this._theme = theme;
   }
 
   onComponentMounted() {
+    if (!this._isConfigured) {
+      return;
+    }
     this._style = injectGlobalStyle(CourierInboxSkeletonListItem.id, CourierInboxSkeletonListItem.getStyles(this._theme));
     this.render();
   }
@@ -70,15 +78,23 @@ class CourierSkeletonAnimatedRow extends CourierBaseElement {
     return 'courier-skeleton-animated-row';
   }
 
-  private _theme: CourierInboxTheme;
+  private _theme!: CourierInboxTheme;
+  private _isConfigured = false;
   private _style?: HTMLStyleElement;
 
-  constructor(theme: CourierInboxTheme) {
+  constructor(theme?: CourierInboxTheme) {
     super();
+    if (!theme) {
+      return;
+    }
+    this._isConfigured = true;
     this._theme = theme;
   }
 
   onComponentMounted() {
+    if (!this._isConfigured) {
+      return;
+    }
     this._style = injectGlobalStyle(CourierSkeletonAnimatedRow.id, CourierSkeletonAnimatedRow.getStyles(this._theme));
     this.render();
   }

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-skeleton-list.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-skeleton-list.ts
@@ -8,15 +8,23 @@ export class CourierInboxSkeletonList extends CourierFactoryElement {
     return 'courier-inbox-skeleton-list';
   }
 
-  private _theme: CourierInboxTheme;
+  private _theme!: CourierInboxTheme;
+  private _isConfigured = false;
   private _style?: HTMLStyleElement;
 
-  constructor(theme: CourierInboxTheme) {
+  constructor(theme?: CourierInboxTheme) {
     super();
+    if (!theme) {
+      return;
+    }
+    this._isConfigured = true;
     this._theme = theme;
   }
 
   onComponentMounted() {
+    if (!this._isConfigured) {
+      return;
+    }
     this._style = injectGlobalStyle(CourierInboxSkeletonList.id, CourierInboxSkeletonList.getStyles(this._theme));
   }
 
@@ -25,6 +33,10 @@ export class CourierInboxSkeletonList extends CourierFactoryElement {
   }
 
   defaultElement(): HTMLElement {
+    if (!this._isConfigured) {
+      return document.createElement('div');
+    }
+
     const list = document.createElement('div');
     list.className = 'list';
 


### PR DESCRIPTION
Harden custom element constructors in the inbox list subtree to prevent crashes during `cloneNode()`.

The `CourierInboxList` and its child components crashed when `cloneNode()` was used because their constructors expected arguments that were not provided by the browser's custom element path. This PR makes these constructors tolerant to no-arg calls and ensures cloned, unconfigured nodes remain inert. A regression test for `cloneNode()` behavior has been added.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e450d29b-8677-4a94-810e-82b8ce75210d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e450d29b-8677-4a94-810e-82b8ce75210d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

