### PR TITLE
fix: always use JWT auth header in designer tests tab, never pass auth token

### DIFF
--- a/designer/app/tests/page.tsx
+++ b/designer/app/tests/page.tsx
@@ -472,7 +472,6 @@ function TestsPageContent() {
       </header>
 
       <CourierAuth
-        skipJwtInitialization
         userIdStorageKey={COURIER_TESTS_USER_ID_STORAGE_KEY}
         apiUrls={committedApiUrls}
         apiKey={sessionCommitted.apiKey.trim() || undefined}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The designer webapp was using the auth token instead of a JWT in the `Authorization: Bearer` header for SDK API calls. This PR ensures the designer always authenticates with JWT only — never `publicApiKey` or auth tokens — matching the behavior of the courier-js tests.

## Root Cause

There were three issues:

### 1. `skipJwtInitialization` skipped JWT generation entirely
The tests page passed `skipJwtInitialization` to `CourierAuth`, which caused it to sign in with `publicApiKey` (the auth token) instead of generating a JWT. The `CourierClient` sets `accessToken = props.jwt ?? props.publicApiKey`, so without a JWT, the auth token was used as the bearer token for all API calls.

### 2. `publicApiKey` was re-injected on every `signIn` call in `CourierTestsTab`
Even after fixing the initial sign-in, three places in `CourierTestsTab.tsx` passed `publicApiKey` when calling `signIn`:
- **Environment change effect**: re-signed in with `publicApiKey` from current client options
- **createRestoreProps / restoreSharedClient**: preserved and restored `publicApiKey` across save/restore cycles
- **Client validation test input snapshot**: included `publicApiKey` in displayed inputs

### 3. `skipJwtInitialization` existed as a prop at all
The `CourierAuth` component offered a `skipJwtInitialization` prop that allowed bypassing JWT and signing in with `publicApiKey`. This entire code path has been removed — the designer webapp should never authenticate with anything other than JWT.

## Changes

### `designer/components/CourierAuth.tsx`
- Removed the `skipJwtInitialization` prop from the interface
- Removed the `skipJwtInitialization` destructuring and default value
- Removed the entire `skipJwtInitialization` branch (which signed in with `publicApiKey`)
- Removed `skipJwtInitialization` from the `useEffect` dependency array
- `isLoading` now always starts as `true` (JWT generation always runs)

### `designer/app/tests/page.tsx`
- Removed `skipJwtInitialization` prop from the `CourierAuth` usage

### `designer/components/CourierTestsTab.tsx`
- Removed `publicApiKey` from the environment-change `signIn` call
- Removed `publicApiKey` from `createRestoreProps` (used by restore/save-restore flows)
- Removed `publicApiKey` from the client validation test's input snapshot

## How it matches courier-js tests

The courier-js integration tests (`@trycourier/courier-js/src/__tests__/utils.ts`) create a `CourierClient` with **only** `jwt` — never `publicApiKey`:

```ts
new CourierClient({
  userId: process.env.USER_ID!,
  jwt: process.env.JWT!,
  apiUrls: { ... },
});
```

The designer now follows the same pattern: JWT is always used for authentication, `publicApiKey` is never passed to `signIn`, and the `skipJwtInitialization` escape hatch no longer exists.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d495e42-75ff-435e-8fad-07f8b6cb2f59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d495e42-75ff-435e-8fad-07f8b6cb2f59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

