### PR TITLE
Add batch size limit of 50 to open requests

### DIFF
--- a/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
@@ -373,6 +373,71 @@ describe("CourierInboxDatastore", () => {
       expect(mockBatchOpen).toHaveBeenLastCalledWith([MSG_2.messageId]);
     });
 
+    it("should split large batches into chunks of 50", async () => {
+      const messages: InboxMessage[] = [];
+      for (let i = 0; i < 120; i++) {
+        messages.push(getMessage());
+      }
+
+      mockGetMessages.mockResolvedValue({
+        data: {
+          count: messages.length,
+          unreadCount: messages.length,
+          messages: {
+            nodes: messages,
+          },
+        },
+      });
+      mockGetUnreadMessageCount.mockResolvedValue(messages.length);
+
+      const datastore = CourierInboxDatastore.shared;
+      await datastore.load({ canUseCache: false });
+
+      for (const msg of messages) {
+        datastore.openMessage({ message: msg });
+      }
+
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+
+      // 120 messages should produce 3 chunks: 50 + 50 + 20
+      expect(mockBatchOpen).toHaveBeenCalledTimes(3);
+      expect(mockBatchOpen.mock.calls[0][0]).toHaveLength(50);
+      expect(mockBatchOpen.mock.calls[1][0]).toHaveLength(50);
+      expect(mockBatchOpen.mock.calls[2][0]).toHaveLength(20);
+    });
+
+    it("should not chunk when batch is within the limit", async () => {
+      const messages: InboxMessage[] = [];
+      for (let i = 0; i < 50; i++) {
+        messages.push(getMessage());
+      }
+
+      mockGetMessages.mockResolvedValue({
+        data: {
+          count: messages.length,
+          unreadCount: messages.length,
+          messages: {
+            nodes: messages,
+          },
+        },
+      });
+      mockGetUnreadMessageCount.mockResolvedValue(messages.length);
+
+      const datastore = CourierInboxDatastore.shared;
+      await datastore.load({ canUseCache: false });
+
+      for (const msg of messages) {
+        datastore.openMessage({ message: msg });
+      }
+
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+
+      expect(mockBatchOpen).toHaveBeenCalledTimes(1);
+      expect(mockBatchOpen.mock.calls[0][0]).toHaveLength(50);
+    });
+
     it("should notify error listeners on batch flush failure", async () => {
       const UNREAD_MESSAGE = getMessage();
 
@@ -402,8 +467,10 @@ describe("CourierInboxDatastore", () => {
       // Optimistic update is still applied
       expect(datastore.getDatasetById('inbox')?.messages[0].opened).toBeDefined();
 
-      // Flush the batch
+      // Flush the batch and allow the rejection to propagate through Promise.all
       jest.advanceTimersByTime(100);
+      await Promise.resolve();
+      await Promise.resolve();
       await Promise.resolve();
 
       expect(onErrorMock).toHaveBeenCalledTimes(1);

--- a/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
@@ -405,6 +405,44 @@ describe("CourierInboxDatastore", () => {
       expect(mockBatchOpen.mock.calls[0][0]).toHaveLength(50);
       expect(mockBatchOpen.mock.calls[1][0]).toHaveLength(50);
       expect(mockBatchOpen.mock.calls[2][0]).toHaveLength(20);
+
+      // No single call should ever exceed 50
+      for (const call of mockBatchOpen.mock.calls) {
+        expect(call[0].length).toBeLessThanOrEqual(50);
+      }
+    });
+
+    it("should chunk when batch is just over the limit", async () => {
+      const messages: InboxMessage[] = [];
+      for (let i = 0; i < 51; i++) {
+        messages.push(getMessage());
+      }
+
+      mockGetMessages.mockResolvedValue({
+        data: {
+          count: messages.length,
+          unreadCount: messages.length,
+          messages: {
+            nodes: messages,
+          },
+        },
+      });
+      mockGetUnreadMessageCount.mockResolvedValue(messages.length);
+
+      const datastore = CourierInboxDatastore.shared;
+      await datastore.load({ canUseCache: false });
+
+      for (const msg of messages) {
+        datastore.openMessage({ message: msg });
+      }
+
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+
+      // 51 messages should produce 2 chunks: 50 + 1
+      expect(mockBatchOpen).toHaveBeenCalledTimes(2);
+      expect(mockBatchOpen.mock.calls[0][0]).toHaveLength(50);
+      expect(mockBatchOpen.mock.calls[1][0]).toHaveLength(1);
     });
 
     it("should not chunk when batch is within the limit", async () => {

--- a/@trycourier/courier-ui-inbox/src/datastore/inbox-datastore.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/inbox-datastore.ts
@@ -32,6 +32,7 @@ interface DatastoreSnapshot {
 export class CourierInboxDatastore {
   private static readonly TAG = "CourierInboxDatastore";
   private static readonly OPEN_BATCH_DELAY_MS = 100;
+  private static readonly OPEN_BATCH_MAX_SIZE = 50;
 
   private static instance: CourierInboxDatastore;
 
@@ -314,8 +315,16 @@ export class CourierInboxDatastore {
 
     if (messageIds.length === 0) return;
 
+    const maxSize = CourierInboxDatastore.OPEN_BATCH_MAX_SIZE;
+    const chunks: string[][] = [];
+    for (let i = 0; i < messageIds.length; i += maxSize) {
+      chunks.push(messageIds.slice(i, i + maxSize));
+    }
+
     try {
-      await Courier.shared.client?.inbox.batchOpen(messageIds);
+      await Promise.all(
+        chunks.map(chunk => Courier.shared.client?.inbox.batchOpen(chunk))
+      );
     } catch (error) {
       Courier.shared.client?.options.logger?.error(
         `[${CourierInboxDatastore.TAG}] Error batch opening messages:`, error


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a max batch size of **50** to the batched open-message requests. Previously, `flushBatchOpen` sent all accumulated message IDs in a single GraphQL mutation with no upper bound, which could produce oversized payloads when many messages become visible at once (e.g. rapid scrolling through a long inbox).

## Changes

### `@trycourier/courier-ui-inbox` — `inbox-datastore.ts`
- Added `OPEN_BATCH_MAX_SIZE = 50` constant alongside the existing `OPEN_BATCH_DELAY_MS`
- Updated `flushBatchOpen` to split accumulated IDs into chunks of 50 and send them as parallel requests via `Promise.all`

### `@trycourier/courier-ui-inbox` — `inbox-datastore.test.ts`
- Added test: **"should split large batches into chunks of 50"** — verifies 120 messages produce 3 chunks (50 + 50 + 20) and asserts no single call exceeds 50
- Added test: **"should chunk when batch is just over the limit"** — verifies 51 messages produce 2 chunks (50 + 1)
- Added test: **"should not chunk when batch is within the limit"** — verifies exactly 50 messages send as a single request
- Fixed error-listener test to flush additional microtask ticks needed by `Promise.all` rejection propagation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f972922-c86d-487f-8e65-9dcf3da20150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f972922-c86d-487f-8e65-9dcf3da20150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

