### PR TITLE
fix(inbox): open CTA href in new tab by default

### DIFF
--- a/@trycourier/courier-react-components/src/components/courier-inbox-component.tsx
+++ b/@trycourier/courier-react-components/src/components/courier-inbox-component.tsx
@@ -26,7 +26,10 @@ export interface CourierInboxProps {
   /** Callback fired when a message is clicked. */
   onMessageClick?: (props: CourierInboxListItemFactoryProps) => void;
 
-  /** Callback fired when a message action (e.g., button) is clicked. */
+  /**
+   * Callback fired when a message action (e.g., button) is clicked.
+   * The inbox also opens `action.href` in a new tab when it is an http(s) URL (before this runs), so file and web links work without a custom handler.
+   */
   onMessageActionClick?: (props: CourierInboxListItemActionFactoryProps) => void;
 
   /** Callback fired when a message is long-pressed (for mobile/gesture support). Only works on devices that support touch. */

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox.ts
@@ -1,4 +1,13 @@
-import { AuthenticationListener, Courier, InboxMessage } from "@trycourier/courier-js";
+import { AuthenticationListener, Courier, InboxAction, InboxMessage } from "@trycourier/courier-js";
+
+/** Opens a message action href in a new tab when set (http/https only). Runs synchronously on button click so popup blockers allow it. */
+function openInboxActionHref(action: InboxAction | undefined): void {
+  const raw = action?.href?.trim();
+  if (!raw || !/^https?:\/\//i.test(raw)) {
+    return;
+  }
+  window.open(raw, "_blank", "noopener,noreferrer");
+}
 import { CourierInboxList } from "./courier-inbox-list";
 import { CourierInboxHeader } from "./courier-inbox-header";
 import { CourierBaseElement, CourierComponentThemeMode, injectGlobalStyle, registerElement } from "@trycourier/courier-ui-core";
@@ -374,6 +383,7 @@ export class CourierInbox extends CourierBaseElement {
         this._onMessageClick?.({ message, index });
       },
       onMessageActionClick: (message, action, index) => {
+        openInboxActionHref(action);
 
         // TODO: Track action click?
 


### PR DESCRIPTION
Message actions already expose href from the API, but the inbox UI only invoked optional callbacks and never navigated. Open safe http(s) hrefs synchronously on click so PDF and file links work without a custom onMessageActionClick handler.

Document the behavior on CourierInbox onMessageActionClick prop.

Made-with: Cursor