### PR TITLE
fix(inbox): guard Custom Element constructors against undefined props

### DIFF
--- a/.changeset/inbox-list-undefined-props.md
+++ b/.changeset/inbox-list-undefined-props.md
@@ -1,0 +1,7 @@
+---
+"@trycourier/courier-ui-inbox": patch
+---
+
+Guard inbox Custom Element constructors against being invoked without props.
+
+`CourierInboxList`, `CourierInboxHeader`, and `CourierInboxPaginationListItem` are registered as Custom Elements, so the browser can construct them with no arguments (e.g. during `cloneNode()` from DOM snapshot libraries like `dom-to-image`). The constructors previously destructured `props` unconditionally and threw an unhandled `TypeError`. They now return early when `props` is undefined. Fixes #150.

--- a/@trycourier/courier-ui-inbox/src/components/__tests__/custom-element-construction.test.ts
+++ b/@trycourier/courier-ui-inbox/src/components/__tests__/custom-element-construction.test.ts
@@ -1,0 +1,55 @@
+import { CourierInboxList } from "../courier-inbox-list";
+import { CourierInboxHeader } from "../courier-inbox-header";
+import { CourierInboxPaginationListItem } from "../courier-inbox-pagination-list-item";
+
+/**
+ * Regression tests for https://github.com/trycourier/courier-web/issues/150
+ *
+ * These components are registered as Custom Elements, so the browser may invoke
+ * their constructors with no arguments (for example, during `cloneNode()` from a
+ * DOM snapshot library). Previously the constructors destructured `props`
+ * unconditionally and threw `TypeError: Cannot read properties of undefined`.
+ */
+describe("Custom Element parameterless construction (issue #150)", () => {
+
+  // jsdom does not implement matchMedia, which a base-class constructor relies on.
+  beforeAll(() => {
+    if (!window.matchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: (query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }),
+      });
+    }
+  });
+
+  it("CourierInboxList does not throw when constructed without props", () => {
+    expect(() => new CourierInboxList()).not.toThrow();
+  });
+
+  it("CourierInboxHeader does not throw when constructed without props", () => {
+    expect(() => new CourierInboxHeader()).not.toThrow();
+  });
+
+  it("CourierInboxPaginationListItem does not throw when constructed without props", () => {
+    expect(() => new CourierInboxPaginationListItem()).not.toThrow();
+  });
+
+  it("cloneNode on a tree containing these elements does not throw", () => {
+    const container = document.createElement("div");
+    container.appendChild(document.createElement(CourierInboxList.id));
+    container.appendChild(document.createElement(CourierInboxHeader.id));
+    container.appendChild(document.createElement(CourierInboxPaginationListItem.id));
+
+    expect(() => container.cloneNode(true)).not.toThrow();
+  });
+
+});

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-header.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-header.ts
@@ -17,7 +17,7 @@ export class CourierInboxHeader extends CourierFactoryElement {
   }
 
   // Theme
-  private _themeSubscription: CourierInboxThemeSubscription;
+  private _themeSubscription!: CourierInboxThemeSubscription;
 
   // State
   private _feeds: CourierInboxFeed[] = [];
@@ -34,10 +34,10 @@ export class CourierInboxHeader extends CourierFactoryElement {
   private _feedButtonClickHandler?: (event: Event) => void;
 
   // Callbacks
-  private _onFeedChange: (feed: CourierInboxFeed) => void;
-  private _onFeedReselected: (feed: CourierInboxFeed) => void;
-  private _onTabChange: (tab: CourierInboxTab) => void;
-  private _onTabReselected: (tab: CourierInboxTab) => void;
+  private _onFeedChange!: (feed: CourierInboxFeed) => void;
+  private _onFeedReselected!: (feed: CourierInboxFeed) => void;
+  private _onTabChange!: (tab: CourierInboxTab) => void;
+  private _onTabReselected!: (tab: CourierInboxTab) => void;
 
   private get theme(): CourierInboxTheme {
     return this._themeSubscription.manager.getTheme();
@@ -49,7 +49,7 @@ export class CourierInboxHeader extends CourierFactoryElement {
     return (currentFeed?.tabs?.length ?? 0) > 1;
   }
 
-  constructor(props: {
+  constructor(props?: {
     themeManager: CourierInboxThemeManager,
     actions?: CourierInboxHeaderAction[],
     onFeedChange: (feed: CourierInboxFeed) => void,
@@ -58,6 +58,13 @@ export class CourierInboxHeader extends CourierFactoryElement {
     onTabReselected: (tab: CourierInboxTab) => void
   }) {
     super();
+
+    // Custom Elements may be constructed without arguments (e.g. the browser invokes
+    // the parameterless constructor during `cloneNode()`). Guard against a missing
+    // `props` so we don't throw an unhandled TypeError. See GitHub issue #150.
+    if (!props) {
+      return;
+    }
 
     // Subscribe to the theme bus
     this._themeSubscription = props.themeManager.subscribe((_) => {

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-list.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-list.ts
@@ -19,7 +19,7 @@ export class CourierInboxList extends CourierBaseElement {
   }
 
   // Theme
-  private _themeSubscription: CourierInboxThemeSubscription;
+  private _themeSubscription!: CourierInboxThemeSubscription;
 
   // State
   private _messages: InboxMessage[] = [];
@@ -35,7 +35,7 @@ export class CourierInboxList extends CourierBaseElement {
   private _onMessageClick: ((message: InboxMessage, index: number) => void) | null = null;
   private _onMessageActionClick: ((message: InboxMessage, action: InboxAction, index: number) => void) | null = null;
   private _onMessageLongPress: ((message: InboxMessage, index: number) => void) | null = null;
-  private _onRefresh: () => void;
+  private _onRefresh!: () => void;
 
   // Factories
   private _onPaginationTrigger?: (feedId: string) => void;
@@ -61,7 +61,7 @@ export class CourierInboxList extends CourierBaseElement {
   private _errorContainer?: CourierInfoState;
   private _emptyContainer?: CourierInfoState;
 
-  constructor(props: {
+  constructor(props?: {
     themeManager: CourierInboxThemeManager,
     listItemActions?: CourierInboxListItemAction[],
     canClickListItems: boolean,
@@ -73,6 +73,13 @@ export class CourierInboxList extends CourierBaseElement {
     onMessageLongPress: (message: InboxMessage, index: number) => void
   }) {
     super();
+
+    // Custom Elements may be constructed without arguments (e.g. the browser invokes
+    // the parameterless constructor during `cloneNode()`). Guard against a missing
+    // `props` so we don't throw an unhandled TypeError. See GitHub issue #150.
+    if (!props) {
+      return;
+    }
 
     // Initialize the callbacks
     this._onRefresh = props.onRefresh;

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox-pagination-list-item.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox-pagination-list-item.ts
@@ -9,7 +9,7 @@ export class CourierInboxPaginationListItem extends CourierBaseElement {
   }
 
   // State
-  private _theme: CourierInboxTheme;
+  private _theme!: CourierInboxTheme;
 
   // Components
   private _style?: HTMLStyleElement;
@@ -18,10 +18,18 @@ export class CourierInboxPaginationListItem extends CourierBaseElement {
   private _customItem?: HTMLElement;
 
   // Handlers
-  private _onPaginationTrigger: () => void;
+  private _onPaginationTrigger!: () => void;
 
-  constructor(props: { theme: CourierInboxTheme, customItem?: HTMLElement, onPaginationTrigger: () => void }) {
+  constructor(props?: { theme: CourierInboxTheme, customItem?: HTMLElement, onPaginationTrigger: () => void }) {
     super();
+
+    // Custom Elements may be constructed without arguments (e.g. the browser invokes
+    // the parameterless constructor during `cloneNode()`). Guard against a missing
+    // `props` so we don't throw an unhandled TypeError. See GitHub issue #150.
+    if (!props) {
+      return;
+    }
+
     this._theme = props.theme;
     this._customItem = props.customItem;
     this._onPaginationTrigger = props.onPaginationTrigger;

--- a/api/courier-js.api.md
+++ b/api/courier-js.api.md
@@ -531,6 +531,7 @@ export class InboxClient extends Client {
 //
 // @public (undocumented)
 export interface InboxMessage {
+    accountId?: string;
     // (undocumented)
     actions?: InboxAction[];
     // (undocumented)

--- a/api/courier-ui-inbox.api.md
+++ b/api/courier-ui-inbox.api.md
@@ -258,7 +258,7 @@ export type CourierInboxFontTheme = CourierFontTheme;
 //
 // @public (undocumented)
 export class CourierInboxHeader extends CourierFactoryElement {
-    constructor(props: {
+    constructor(props?: {
         themeManager: CourierInboxThemeManager;
         actions?: CourierInboxHeaderAction[];
         onFeedChange: (feed: CourierInboxFeed) => void;


### PR DESCRIPTION
## Summary

Fixes #150.

`CourierInboxList`, `CourierInboxHeader`, and `CourierInboxPaginationListItem` are registered as Custom Elements. The browser may therefore invoke their constructors **without arguments** — most notably during `cloneNode()`, which DOM snapshot libraries like `dom-to-image` call on the whole document tree. The constructors destructured `props` unconditionally:

```ts
this._onRefresh = props.onRefresh; // props is undefined → TypeError
```

This surfaced as an uncaught `window.onerror` event that React Error Boundaries cannot catch:

```
TypeError: Cannot read properties of undefined (reading 'onRefresh')
    at new CourierInboxList (@trycourier/courier-ui-inbox/dist/index.mjs)
    at makeNodeCopy (dom-to-image/src/dom-to-image.js:192:25)
```

## Fix

- Make the `props` parameter optional and `return` early when it is `undefined`, per [Custom Element conformance](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance). When constructed without props the element is inert (it is never connected/upgraded with data), which matches how the browser uses the parameterless path.
- Add definite-assignment assertions (`!`) to the fields that are only assigned from `props`, so the early return type-checks under `strictPropertyInitialization`. Fields with default initializers are unaffected.
- Apply the same guard to all three Custom Element constructors that take required props.

## Testing

- New regression test `custom-element-construction.test.ts` covers both parameterless construction and the `cloneNode()` path that originally triggered the crash.
- `yarn build` and the full `jest` suite (53 tests) pass.

Linear: [C-18803](https://linear.app/trycourier/issue/C-18803)

🤖 Generated with [Claude Code](https://claude.com/claude-code)