### PR TITLE
fix(courier-js): encode dynamic path segments in REST requests

### DIFF
--- a/.changeset/courier-js-url-encoding.md
+++ b/.changeset/courier-js-url-encoding.md
@@ -1,0 +1,7 @@
+---
+"@trycourier/courier-js": patch
+---
+
+Encode dynamic path segments in REST requests.
+
+`userId`, `token`, and `listId` were interpolated into REST URLs without encoding. Values containing `/`, `?`, `#`, or `..` could alter the request path or query string. These segments are now passed through `encodeURIComponent` in the token and list clients.

--- a/@trycourier/courier-js/src/client/list-client.ts
+++ b/@trycourier/courier-js/src/client/list-client.ts
@@ -15,7 +15,7 @@ export class ListClient extends Client {
   public async putSubscription(props: { listId: string; clientKey: string; }): Promise<void> {
     this.options.logger.warn('Courier Warning: The clientKey parameter in putSubscription is deprecated and will be removed in a future release.');
     return await http({
-      url: `${this.options.apiUrls.courier.rest}/client/lists/${props.listId}/subscribe/${this.options.userId}`,
+      url: `${this.options.apiUrls.courier.rest}/client/lists/${encodeURIComponent(props.listId)}/subscribe/${encodeURIComponent(this.options.userId)}`,
       options: this.options,
       method: 'PUT',
       headers: {
@@ -37,7 +37,7 @@ export class ListClient extends Client {
   public async deleteSubscription(props: { listId: string; clientKey: string; }): Promise<void> {
     this.options.logger.warn('Courier Warning: The clientKey parameter in deleteSubscription is deprecated and will be removed in a future release.');
     return await http({
-      url: `${this.options.apiUrls.courier.rest}/client/lists/${props.listId}/unsubscribe/${this.options.userId}`,
+      url: `${this.options.apiUrls.courier.rest}/client/lists/${encodeURIComponent(props.listId)}/unsubscribe/${encodeURIComponent(this.options.userId)}`,
       options: this.options,
       method: 'DELETE',
       headers: {

--- a/@trycourier/courier-js/src/client/token-client.ts
+++ b/@trycourier/courier-js/src/client/token-client.ts
@@ -32,7 +32,7 @@ export class TokenClient extends Client {
 
     await http({
       options: this.options,
-      url: `${this.options.apiUrls.courier.rest}/users/${this.options.userId}/tokens/${props.token}`,
+      url: `${this.options.apiUrls.courier.rest}/users/${encodeURIComponent(this.options.userId)}/tokens/${encodeURIComponent(props.token)}`,
       method: 'PUT',
       headers: {
         'Authorization': `Bearer ${this.options.accessToken}`
@@ -52,7 +52,7 @@ export class TokenClient extends Client {
   }): Promise<void> {
     await http({
       options: this.options,
-      url: `${this.options.apiUrls.courier.rest}/users/${this.options.userId}/tokens/${props.token}`,
+      url: `${this.options.apiUrls.courier.rest}/users/${encodeURIComponent(this.options.userId)}/tokens/${encodeURIComponent(props.token)}`,
       method: 'DELETE',
       headers: {
         'Authorization': `Bearer ${this.options.accessToken}`

--- a/api/courier-js.api.md
+++ b/api/courier-js.api.md
@@ -531,6 +531,7 @@ export class InboxClient extends Client {
 //
 // @public (undocumented)
 export interface InboxMessage {
+    accountId?: string;
     // (undocumented)
     actions?: InboxAction[];
     // (undocumented)


### PR DESCRIPTION
## Summary

The token and list REST clients interpolated identifiers directly into request URLs without encoding:

- `token-client.ts` — `GET/PUT/DELETE /users/{userId}/tokens/{token}` (`userId`, `token`)
- `list-client.ts` — `PUT /client/lists/{listId}/subscribe/{userId}` and the unsubscribe variant (`listId`, `userId`)

A value containing `/`, `?`, `#`, or `..` could change which path the request targets or append query parameters — path/parameter injection within the caller's authenticated scope.

## Fix

Wrap each dynamic segment in `encodeURIComponent`. No behavior change for well-formed ids.

## Testing

Full `@trycourier/courier-js` suite passes (80 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)