### PR TITLE
fix(ui): reject javascript: and other unsafe schemes in link hrefs

### DIFF
--- a/.changeset/ui-href-scheme-validation.md
+++ b/.changeset/ui-href-scheme-validation.md
@@ -1,0 +1,10 @@
+---
+"@trycourier/courier-ui-core": patch
+"@trycourier/courier-ui-preferences": patch
+---
+
+Reject dangerous URL schemes in link targets.
+
+The `courier-link` component and the preferences brand logo assigned externally-sourced values straight to an anchor's `href`. A value such as `javascript:alert(1)` would execute when the link was clicked (DOM-based XSS).
+
+Adds a `sanitizeUrl` helper to `@trycourier/courier-ui-core` that only allows `http`, `https`, `mailto`, `tel`, and relative URLs (and strips control characters that browsers would otherwise use to hide a scheme). Both link sinks now run their href through it; unsafe values render no link rather than a scriptable one.

--- a/@trycourier/courier-ui-core/jest.config.ts
+++ b/@trycourier/courier-ui-core/jest.config.ts
@@ -1,0 +1,21 @@
+export default /** @type {import('ts-jest').JestConfigWithTsJest} */ ({
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      { useESM: true, tsconfig: './tsconfig.json' }
+    ]
+  },
+
+  transformIgnorePatterns: ['/node_modules/(?!@trycourier/)'],
+  moduleNameMapper: { '^(\\.{1,2}/.*)\\.js$': '$1' },
+
+  roots: ['<rootDir>/src'],
+  testMatch: [
+    '**/__tests__/**/*(spec|test).ts?(x)',
+    '**/?(*.)+(spec|test).ts?(x)'
+  ],
+});

--- a/@trycourier/courier-ui-core/package.json
+++ b/@trycourier/courier-ui-core/package.json
@@ -12,7 +12,7 @@
     "watch": "vite build --watch",
     "preview": "vite preview",
     "prepare": "npm run build",
-    "test": "echo \"courier-ui-core has no tests\"",
+    "test": "jest",
     "generate-api-doc": "api-extractor run"
   },
   "keywords": [

--- a/@trycourier/courier-ui-core/src/components/courier-link.ts
+++ b/@trycourier/courier-ui-core/src/components/courier-link.ts
@@ -1,3 +1,4 @@
+import { sanitizeUrl } from "../utils/sanitize-url";
 import { theme } from "../utils/theme";
 import { CourierBaseElement } from "./courier-base-element";
 
@@ -128,8 +129,11 @@ export class CourierLink extends CourierBaseElement {
 
   private updateHref() {
     const href = this.getAttribute('href');
-    if (href) {
-      this.link.href = href;
+    const safeHref = sanitizeUrl(href);
+    if (safeHref) {
+      this.link.href = safeHref;
+    } else {
+      this.link.removeAttribute('href');
     }
   }
 

--- a/@trycourier/courier-ui-core/src/index.ts
+++ b/@trycourier/courier-ui-core/src/index.ts
@@ -24,6 +24,7 @@ export * from './utils/system-theme-mode';
 export * from './utils/theme';
 export * from './utils/courier-colors';
 export * from './utils/registeration';
+export * from './utils/sanitize-url';
 
 // Export theme management
 export * from './managers/courier-theme-manager';

--- a/@trycourier/courier-ui-core/src/utils/__tests__/sanitize-url.test.ts
+++ b/@trycourier/courier-ui-core/src/utils/__tests__/sanitize-url.test.ts
@@ -1,0 +1,39 @@
+import { sanitizeUrl } from '../sanitize-url';
+
+describe('sanitizeUrl', () => {
+  it('allows safe schemes', () => {
+    expect(sanitizeUrl('https://example.com/path?q=1')).toBe('https://example.com/path?q=1');
+    expect(sanitizeUrl('http://example.com')).toBe('http://example.com');
+    expect(sanitizeUrl('mailto:a@b.com')).toBe('mailto:a@b.com');
+    expect(sanitizeUrl('tel:+15555555555')).toBe('tel:+15555555555');
+  });
+
+  it('allows relative and fragment URLs', () => {
+    expect(sanitizeUrl('/foo/bar')).toBe('/foo/bar');
+    expect(sanitizeUrl('#section')).toBe('#section');
+    expect(sanitizeUrl('?q=1')).toBe('?q=1');
+    expect(sanitizeUrl('example.com/path')).toBe('example.com/path');
+  });
+
+  it('rejects javascript: and other dangerous schemes', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBeNull();
+    expect(sanitizeUrl('JavaScript:alert(1)')).toBeNull();
+    expect(sanitizeUrl('  javascript:alert(1)')).toBeNull();
+    expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(sanitizeUrl('vbscript:msgbox(1)')).toBeNull();
+    expect(sanitizeUrl('blob:https://example.com/uuid')).toBeNull();
+  });
+
+  it('rejects schemes hidden behind control characters that browsers strip', () => {
+    expect(sanitizeUrl('java\nscript:alert(1)')).toBeNull();
+    expect(sanitizeUrl('java\tscript:alert(1)')).toBeNull();
+    expect(sanitizeUrl('java\x00script:alert(1)')).toBeNull();
+  });
+
+  it('returns null for empty or non-string values', () => {
+    expect(sanitizeUrl('')).toBeNull();
+    expect(sanitizeUrl('   ')).toBeNull();
+    expect(sanitizeUrl(null)).toBeNull();
+    expect(sanitizeUrl(undefined)).toBeNull();
+  });
+});

--- a/@trycourier/courier-ui-core/src/utils/sanitize-url.ts
+++ b/@trycourier/courier-ui-core/src/utils/sanitize-url.ts
@@ -1,0 +1,46 @@
+/**
+ * URL schemes that are safe to use as a link target. Notably this excludes
+ * `javascript:`, `data:`, `vbscript:`, and `blob:`, which can execute script
+ * or smuggle active content when assigned to an anchor's `href`.
+ */
+const SAFE_URL_SCHEMES = ['http:', 'https:', 'mailto:', 'tel:'];
+
+/**
+ * Control characters (including tab, newline, carriage return). Browsers strip
+ * these from URLs before parsing, so `java\nscript:...` resolves to
+ * `javascript:...`. We strip them too before detecting the scheme, otherwise
+ * an attacker could hide a dangerous scheme from the check below.
+ */
+const URL_CONTROL_CHARS = /[\u0000-\u001F\u007F]/g;
+
+/**
+ * Returns the URL unchanged if it uses a safe scheme (or is a scheme-relative /
+ * relative URL), otherwise returns `null`.
+ *
+ * Use this before assigning any externally-sourced value (brand config,
+ * notification data, etc.) to an element's `href` so a value like
+ * `javascript:alert(1)` cannot run when the link is clicked.
+ */
+export function sanitizeUrl(url: string | null | undefined): string | null {
+  if (typeof url !== 'string') return null;
+
+  // Strip control characters (matching browser URL parsing) before inspecting
+  // the scheme, then trim surrounding whitespace.
+  const cleaned = url.replace(URL_CONTROL_CHARS, '').trim();
+  if (!cleaned) return null;
+
+  // Relative and protocol-relative URLs have no scheme of their own and resolve
+  // against the current document's origin, so they are safe to allow.
+  if (cleaned.startsWith('/') || cleaned.startsWith('#') || cleaned.startsWith('?')) {
+    return cleaned;
+  }
+
+  // If there's no scheme delimiter, treat it as a relative URL.
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):/i.exec(cleaned);
+  if (!schemeMatch) {
+    return cleaned;
+  }
+
+  const scheme = schemeMatch[1].toLowerCase() + ':';
+  return SAFE_URL_SCHEMES.includes(scheme) ? cleaned : null;
+}

--- a/@trycourier/courier-ui-preferences/src/components/courier-preferences.ts
+++ b/@trycourier/courier-ui-preferences/src/components/courier-preferences.ts
@@ -6,7 +6,7 @@ import {
   CourierPreferencePage,
   RecipientPreference,
 } from "@trycourier/courier-js";
-import { CourierBaseElement, CourierComponentThemeMode, registerElement, injectGlobalStyle, CourierInfoState } from "@trycourier/courier-ui-core";
+import { CourierBaseElement, CourierComponentThemeMode, registerElement, injectGlobalStyle, CourierInfoState, sanitizeUrl } from "@trycourier/courier-ui-core";
 import { CourierPreferencesTheme, defaultLightTheme, DEFAULT_PREFERENCES_PRIMARY_COLOR } from "../types/courier-preferences-theme";
 import { CourierPreferencesThemeManager } from "../types/courier-preferences-theme-manager";
 import { PreferencesSection, PreferencesTopic } from "../types/preferences";
@@ -500,9 +500,10 @@ export class CourierPreferences extends CourierBaseElement {
       const logoContainer = document.createElement('div');
       logoContainer.className = 'courier-preferences-logo';
 
-      if (this._brand.logo.href) {
+      const safeHref = sanitizeUrl(this._brand.logo.href);
+      if (safeHref) {
         const logoLink = document.createElement('a');
-        logoLink.href = this._brand.logo.href;
+        logoLink.href = safeHref;
         logoLink.target = '_blank';
         logoLink.rel = 'noopener noreferrer';
         const logoImg = document.createElement('img');

--- a/api/courier-js.api.md
+++ b/api/courier-js.api.md
@@ -531,6 +531,7 @@ export class InboxClient extends Client {
 //
 // @public (undocumented)
 export interface InboxMessage {
+    accountId?: string;
     // (undocumented)
     actions?: InboxAction[];
     // (undocumented)

--- a/api/courier-ui-core.api.md
+++ b/api/courier-ui-core.api.md
@@ -414,6 +414,11 @@ export function registerElement(element: CustomElementConstructor & {
     id: string;
 }): void;
 
+// Warning: (ae-missing-release-tag) "sanitizeUrl" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
+//
+// @public
+export function sanitizeUrl(url: string | null | undefined): string | null;
+
 // Warning: (ae-missing-release-tag) "SystemThemeMode" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)


### PR DESCRIPTION
## Summary

Two components assigned externally-sourced values directly to an anchor's `href`, with no scheme validation:

- **`courier-ui-core` `courier-link.ts`** — `updateHref()` set `this.link.href = href` straight from the `href` attribute.
- **`courier-ui-preferences` `courier-preferences.ts`** — the brand logo set `logoLink.href = this._brand.logo.href`, where the brand comes from workspace/tenant configuration fetched via the API.

A value like `javascript:alert(1)` executes in the page when the link is clicked — DOM-based XSS. In a white-label / multi-tenant preferences page, a tenant-controlled brand logo href is an attacker-influenced input shown to end users.

## Fix

New `sanitizeUrl` helper in `@trycourier/courier-ui-core`:
- Allows `http:`, `https:`, `mailto:`, `tel:`, and relative / fragment / protocol-relative URLs.
- Rejects everything else (`javascript:`, `data:`, `vbscript:`, `blob:`, …), returning `null`.
- Strips control characters first, so a scheme can't be smuggled past the check via `java\nscript:` (browsers strip those before parsing).

Both sinks now run their value through `sanitizeUrl`; an unsafe value renders no link/`href` rather than a scriptable one.

## Testing

- New `sanitize-url.test.ts` (5 cases: safe schemes, relative URLs, dangerous schemes, control-char smuggling, empty/non-string). This adds a `jest` test runner config to `courier-ui-core`, which previously had none.
- `courier-ui-preferences` typechecks and its existing suite passes (37 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)