### PR TITLE
docs: add package architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,52 @@ The Courier Web monorepo uses [Yarn workspaces](https://classic.yarnpkg.com/blog
 | [`courier-ui-core`](./@trycourier/courier-ui-core) | Web components used in UI level packages |
 | [`courier-ui-inbox`](./@trycourier/courier-ui-inbox) | Web components for Courier Inbox |
 | [`courier-ui-toast`](./@trycourier/courier-ui-toast) | Web components for Courier Toast |
+| [`courier-ui-preferences`](./@trycourier/courier-ui-preferences) | Web components for Courier Preferences |
 | [`courier-react-components`](./@trycourier/courier-react-components/) | Shared package of React components for `courier-react` and `courier-react-17` |
 | [`courier-react`](./@trycourier/courier-react) | React 18+ components for Courier Inbox |
 | [`courier-react-17`](./@trycourier/courier-react-17/) | React 17 components for Courier Inbox |
+| [`courier-vue`](./@trycourier/courier-vue) | Vue 3 components for Courier Inbox |
+| [`courier-angular`](./@trycourier/courier-angular) | Angular 17+ components for Courier Inbox |
+
+### Architecture
+
+```mermaid
+graph TD
+    subgraph foundation["Foundation"]
+        js["courier-js<br/><i>API client</i>"]
+        core["courier-ui-core<br/><i>base web components</i>"]
+    end
+
+    subgraph webcomponents["Web Component UI"]
+        inbox["courier-ui-inbox"]
+        toast["courier-ui-toast"]
+        prefs["courier-ui-preferences"]
+    end
+
+    subgraph reactsdks["React SDKs"]
+        rc["courier-react-components<br/><i>shared</i>"]
+        r18["courier-react<br/><i>React 18+</i>"]
+        r17["courier-react-17<br/><i>React 17</i>"]
+    end
+
+    subgraph nativesdks["Native Framework SDKs"]
+        vue["courier-vue<br/><i>Vue 3</i>"]
+        ng["courier-angular<br/><i>Angular 17+</i>"]
+    end
+
+    inbox --> js & core
+    toast --> js & core
+    prefs --> js & core
+
+    rc --> inbox & toast & prefs
+    r18 --> rc
+    r17 --> rc
+
+    vue --> inbox & toast & prefs
+    ng --> inbox & toast & prefs
+```
+
+The `courier-js` API client and `courier-ui-core` web components form the foundation. The `courier-ui-*` packages build the framework-agnostic web component UI on top of them. Framework SDKs wrap those web components: the React SDKs share logic through `courier-react-components`, while `courier-vue` and `courier-angular` wrap the web components directly.
 
 ## API Extractor
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3521,10 +3521,10 @@
   version "1.0.0"
   dependencies:
     "@trycourier/courier-js" "3.4.0"
-    "@trycourier/courier-ui-core" "2.2.0"
-    "@trycourier/courier-ui-inbox" "2.4.7"
-    "@trycourier/courier-ui-preferences" "1.1.0"
-    "@trycourier/courier-ui-toast" "2.1.6"
+    "@trycourier/courier-ui-core" "2.2.1"
+    "@trycourier/courier-ui-inbox" "2.4.8"
+    "@trycourier/courier-ui-preferences" "1.1.1"
+    "@trycourier/courier-ui-toast" "2.1.7"
     tslib "^2.8.1"
 
 "@trycourier/courier-react-17@file:@trycourier/courier-react-17":
@@ -3557,46 +3557,17 @@
     "@trycourier/courier-ui-preferences" "1.1.1"
     "@trycourier/courier-ui-toast" "2.1.7"
 
-"@trycourier/courier-ui-core@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@trycourier/courier-ui-core/-/courier-ui-core-2.2.0.tgz#82c19453f8df3af1802f6d164c8b64f696898308"
-  integrity sha512-EPejn9kt+AP1CJKbveg1neh8X8XwD/jSagcoO/wF491wlpXJ2PZoIP90s6pTV503wSU6WPz18yx/P4XagQ4PfA==
-
-"@trycourier/courier-ui-inbox@2.4.7":
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/@trycourier/courier-ui-inbox/-/courier-ui-inbox-2.4.7.tgz#314c005c26d5a9a24ecb83c823cd34529c86ef43"
-  integrity sha512-8CxR5i+ICr7BiMQmtl9FNC6W0cPrn3jx5xlkWS7sZ0NktyDKEuZA2PkLQSBybk45wU5JkhEmpOvvVTDqZBUDsA==
-  dependencies:
-    "@trycourier/courier-js" "3.4.0"
-    "@trycourier/courier-ui-core" "2.2.0"
-
 "@trycourier/courier-ui-inbox@file:@trycourier/courier-ui-inbox":
   version "2.4.8"
   dependencies:
     "@trycourier/courier-js" "3.4.0"
     "@trycourier/courier-ui-core" "2.2.1"
 
-"@trycourier/courier-ui-preferences@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@trycourier/courier-ui-preferences/-/courier-ui-preferences-1.1.0.tgz#684845d012039f8cd119c557d15175102dff29ba"
-  integrity sha512-6zySrQCZbrLEeLTtsiquD16OIpnVU0QkmLxYFiox3FTfAEXz/lK1SZIWQW4jxQ5jIYe+UEdGsWQJmiQT87zO+w==
-  dependencies:
-    "@trycourier/courier-js" "3.4.0"
-    "@trycourier/courier-ui-core" "2.2.0"
-
 "@trycourier/courier-ui-preferences@file:@trycourier/courier-ui-preferences":
   version "1.1.1"
   dependencies:
     "@trycourier/courier-js" "3.4.0"
     "@trycourier/courier-ui-core" "2.2.1"
-
-"@trycourier/courier-ui-toast@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@trycourier/courier-ui-toast/-/courier-ui-toast-2.1.6.tgz#df0a5ef94650917317f712421d102a5cf4e115e9"
-  integrity sha512-5IpuxAhWN6edKM9qcf+NGsGI7kO9pSzzTazjcXfhW9UR2vdGVKQcNjLDeJE6mjeVgttBiN2hUkpg6J77wu9JCg==
-  dependencies:
-    "@trycourier/courier-js" "3.4.0"
-    "@trycourier/courier-ui-core" "2.2.0"
 
 "@trycourier/courier-ui-toast@file:@trycourier/courier-ui-toast":
   version "2.1.7"
@@ -3608,10 +3579,10 @@
   version "1.0.0"
   dependencies:
     "@trycourier/courier-js" "3.4.0"
-    "@trycourier/courier-ui-core" "2.2.0"
-    "@trycourier/courier-ui-inbox" "2.4.7"
-    "@trycourier/courier-ui-preferences" "1.1.0"
-    "@trycourier/courier-ui-toast" "2.1.6"
+    "@trycourier/courier-ui-core" "2.2.1"
+    "@trycourier/courier-ui-inbox" "2.4.8"
+    "@trycourier/courier-ui-preferences" "1.1.1"
+    "@trycourier/courier-ui-toast" "2.1.7"
 
 "@trycourier/courier@^7.3.0":
   version "7.3.0"


### PR DESCRIPTION
## What

- Adds an **Architecture** subsection to the root README with a mermaid diagram of the package dependency layers (foundation → web-component UI → React SDKs / native framework SDKs).
- Fills in the three Packages-table rows that were missing: `courier-ui-preferences`, `courier-vue`, `courier-angular`.
- Syncs `yarn.lock` with the `courier-vue` / `courier-angular` UI dependency pins (`2.2.1 / 2.4.8 / 2.1.7 / 1.1.1`). Those pins were bumped in #198, but the lockfile was left at the old versions — so `main` currently has `package.json` and `yarn.lock` out of sync. This corrects it.

## Why

`main` already documents the React packages but not the new native SDKs, and the package relationships weren't captured anywhere visually. GitHub renders mermaid natively, so the diagram shows on the repo page.

## Notes

- No source/behavior changes — docs + lockfile only.
- No changeset (no published-package version impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)