### PR TITLE
docs: fix architecture diagram flow direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The Courier Web monorepo uses [Yarn workspaces](https://classic.yarnpkg.com/blog
 ### Architecture
 
 ```mermaid
-graph TD
+graph BT
     subgraph foundation["Foundation"]
         js["courier-js<br/><i>API client</i>"]
         core["courier-ui-core<br/><i>base web components</i>"]
@@ -83,16 +83,12 @@ graph TD
         ng["courier-angular<br/><i>Angular 17+</i>"]
     end
 
-    inbox --> js & core
-    toast --> js & core
-    prefs --> js & core
+    js & core --> inbox & toast & prefs
 
-    rc --> inbox & toast & prefs
-    r18 --> rc
-    r17 --> rc
+    inbox & toast & prefs --> rc
+    rc --> r18 & r17
 
-    vue --> inbox & toast & prefs
-    ng --> inbox & toast & prefs
+    inbox & toast & prefs --> vue & ng
 ```
 
 The `courier-js` API client and `courier-ui-core` web components form the foundation. The `courier-ui-*` packages build the framework-agnostic web component UI on top of them. Framework SDKs wrap those web components: the React SDKs share logic through `courier-react-components`, while `courier-vue` and `courier-angular` wrap the web components directly.


### PR DESCRIPTION
Follow-up to #199.

The diagram added in #199 had the arrows pointing the wrong way (consumer → dependency, top-down). This flips them so the **flow reads from the `courier-js` / `courier-ui-core` foundation up through the web-component UI layer to the framework SDKs** — switching to `graph BT` and reversing every edge.

Diagram-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)