### PR TITLE
chore(examples): tidy showcase demos (react-17, react-latest, vue)

### DIFF
--- a/examples/react-17/src/CustomHeight.tsx
+++ b/examples/react-17/src/CustomHeight.tsx
@@ -13,9 +13,7 @@ export default function App() {
   }, []);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox height='50vh' />
-    </div>
+    <CourierInbox height='50vh' />
   );
 
 }

--- a/examples/react-17/src/ElementRef.tsx
+++ b/examples/react-17/src/ElementRef.tsx
@@ -24,9 +24,7 @@ export default function App() {
   }, [inboxRef.current]);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox ref={inboxRef} />
-    </div>
+    <CourierInbox ref={inboxRef} />
   );
 
 }

--- a/examples/react-17/src/InboxActions.tsx
+++ b/examples/react-17/src/InboxActions.tsx
@@ -18,23 +18,21 @@ export default function App() {
   }, []);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox
-        onMessageClick={({ message, index }: CourierInboxListItemFactoryProps) => {
-          alert("Message clicked at index " + index + ":\n" + JSON.stringify(message, null, 2));
-        }}
-        onMessageActionClick={({ message, action, index }: CourierInboxListItemActionFactoryProps) => {
-          alert(
-            "Message action clicked at index " + index + ":\n" +
-            "Action: " + JSON.stringify(action, null, 2) + "\n" +
-            "Message: " + JSON.stringify(message, null, 2)
-          );
-        }}
-        onMessageLongPress={({ message, index }: CourierInboxListItemFactoryProps) => {
-          alert("Message long pressed at index " + index + ":\n" + JSON.stringify(message, null, 2));
-        }}
-      />
-    </div>
+    <CourierInbox
+      onMessageClick={({ message, index }: CourierInboxListItemFactoryProps) => {
+        alert("Message clicked at index " + index + ":\n" + JSON.stringify(message, null, 2));
+      }}
+      onMessageActionClick={({ message, action, index }: CourierInboxListItemActionFactoryProps) => {
+        alert(
+          "Message action clicked at index " + index + ":\n" +
+          "Action: " + JSON.stringify(action, null, 2) + "\n" +
+          "Message: " + JSON.stringify(message, null, 2)
+        );
+      }}
+      onMessageLongPress={({ message, index }: CourierInboxListItemFactoryProps) => {
+        alert("Message long pressed at index " + index + ":\n" + JSON.stringify(message, null, 2));
+      }}
+    />
   );
 
 }

--- a/examples/react-17/src/InboxCustomFeed.tsx
+++ b/examples/react-17/src/InboxCustomFeed.tsx
@@ -79,9 +79,7 @@ export default function InboxCustomFeed() {
   ];
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox feeds={feeds} />
-    </div>
+    <CourierInbox feeds={feeds} />
   );
 
 }

--- a/examples/react-17/src/InboxCustomTabs.tsx
+++ b/examples/react-17/src/InboxCustomTabs.tsx
@@ -52,9 +52,7 @@ export default function InboxCustomTabs() {
   ];
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox feeds={feeds} />
-    </div>
+    <CourierInbox feeds={feeds} />
   );
 
 }

--- a/examples/react-17/src/InboxDefault.tsx
+++ b/examples/react-17/src/InboxDefault.tsx
@@ -13,9 +13,7 @@ export default function App() {
   }, []);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox />
-    </div>
+    <CourierInbox />
   );
 
 }

--- a/examples/react-17/src/InboxTheme.tsx
+++ b/examples/react-17/src/InboxTheme.tsx
@@ -165,9 +165,7 @@ export default function App() {
   };
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox lightTheme={theme} darkTheme={theme} mode="light" />
-    </div>
+    <CourierInbox lightTheme={theme} darkTheme={theme} mode="light" />
   );
 }
 

--- a/examples/react-17/src/MarkdownListItem.tsx
+++ b/examples/react-17/src/MarkdownListItem.tsx
@@ -26,17 +26,15 @@ export default function MarkdownListItemInbox() {
   }, [courierJwt]);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox
-        renderListItem={props => {
-          return (
-            <div>
-              <Markdown>{props?.message?.preview || ""}</Markdown>
-            </div>
-          );
-        }}
-      />
-    </div>
+    <CourierInbox
+      renderListItem={props => {
+        return (
+          <div>
+            <Markdown>{props?.message?.preview || ""}</Markdown>
+          </div>
+        );
+      }}
+    />
   );
 }
 

--- a/examples/react-latest/src/CustomHeight.tsx
+++ b/examples/react-latest/src/CustomHeight.tsx
@@ -13,9 +13,7 @@ export default function App() {
   }, []);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox height='50vh' />
-    </div>
+    <CourierInbox height='50vh' />
   );
 
 }

--- a/examples/react-latest/src/ElementRef.tsx
+++ b/examples/react-latest/src/ElementRef.tsx
@@ -24,9 +24,7 @@ export default function App() {
   }, [inboxRef.current]);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox ref={inboxRef} />
-    </div>
+    <CourierInbox ref={inboxRef} />
   );
 
 }

--- a/examples/react-latest/src/InboxActions.tsx
+++ b/examples/react-latest/src/InboxActions.tsx
@@ -18,23 +18,21 @@ export default function App() {
   }, []);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox
-        onMessageClick={({ message, index }: CourierInboxListItemFactoryProps) => {
-          alert("Message clicked at index " + index + ":\n" + JSON.stringify(message, null, 2));
-        }}
-        onMessageActionClick={({ message, action, index }: CourierInboxListItemActionFactoryProps) => {
-          alert(
-            "Message action clicked at index " + index + ":\n" +
-            "Action: " + JSON.stringify(action, null, 2) + "\n" +
-            "Message: " + JSON.stringify(message, null, 2)
-          );
-        }}
-        onMessageLongPress={({ message, index }: CourierInboxListItemFactoryProps) => {
-          alert("Message long pressed at index " + index + ":\n" + JSON.stringify(message, null, 2));
-        }}
-      />
-    </div>
+    <CourierInbox
+      onMessageClick={({ message, index }: CourierInboxListItemFactoryProps) => {
+        alert("Message clicked at index " + index + ":\n" + JSON.stringify(message, null, 2));
+      }}
+      onMessageActionClick={({ message, action, index }: CourierInboxListItemActionFactoryProps) => {
+        alert(
+          "Message action clicked at index " + index + ":\n" +
+          "Action: " + JSON.stringify(action, null, 2) + "\n" +
+          "Message: " + JSON.stringify(message, null, 2)
+        );
+      }}
+      onMessageLongPress={({ message, index }: CourierInboxListItemFactoryProps) => {
+        alert("Message long pressed at index " + index + ":\n" + JSON.stringify(message, null, 2));
+      }}
+    />
   );
 
 }

--- a/examples/react-latest/src/InboxCustomFeed.tsx
+++ b/examples/react-latest/src/InboxCustomFeed.tsx
@@ -87,9 +87,7 @@ export default function InboxCustomFeed() {
   ];
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox feeds={feeds} />
-    </div>
+    <CourierInbox feeds={feeds} />
   );
 
 }

--- a/examples/react-latest/src/InboxCustomTabs.tsx
+++ b/examples/react-latest/src/InboxCustomTabs.tsx
@@ -52,9 +52,7 @@ export default function InboxCustomTabs() {
   ];
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox feeds={feeds} />
-    </div>
+    <CourierInbox feeds={feeds} />
   );
 
 }

--- a/examples/react-latest/src/InboxDefault.tsx
+++ b/examples/react-latest/src/InboxDefault.tsx
@@ -23,9 +23,7 @@ export default function App() {
   }, []);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox />
-    </div>
+    <CourierInbox />
   );
 
 }

--- a/examples/react-latest/src/InboxTheme.tsx
+++ b/examples/react-latest/src/InboxTheme.tsx
@@ -165,8 +165,6 @@ export default function App() {
   };
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox lightTheme={theme} darkTheme={theme} mode="light" />
-    </div>
+    <CourierInbox lightTheme={theme} darkTheme={theme} mode="light" />
   );
 }

--- a/examples/react-latest/src/MarkdownListItem.tsx
+++ b/examples/react-latest/src/MarkdownListItem.tsx
@@ -26,16 +26,14 @@ export default function MarkdownListItemInbox() {
   }, [courierJwt]);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <CourierInbox
-        renderListItem={props => {
-          return (
-            <div>
-              <Markdown>{props?.message?.preview || ""}</Markdown>
-            </div>
-          );
-        }}
-      />
-    </div>
+    <CourierInbox
+      renderListItem={props => {
+        return (
+          <div>
+            <Markdown>{props?.message?.preview || ""}</Markdown>
+          </div>
+        );
+      }}
+    />
   );
 }

--- a/examples/vue/src/CustomHeight.vue
+++ b/examples/vue/src/CustomHeight.vue
@@ -13,7 +13,5 @@ onMounted(() => {
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox height="50vh" />
-  </div>
+  <CourierInbox height="50vh" />
 </template>

--- a/examples/vue/src/ElementRef.vue
+++ b/examples/vue/src/ElementRef.vue
@@ -18,7 +18,5 @@ onMounted(() => {
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox ref="inboxComp" />
-  </div>
+  <CourierInbox ref="inboxComp" />
 </template>

--- a/examples/vue/src/InboxActions.vue
+++ b/examples/vue/src/InboxActions.vue
@@ -34,11 +34,9 @@ const handleMessageLongPress = ({ message, index }: CourierInboxListItemFactoryP
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox
-      :on-message-click="handleMessageClick"
-      :on-message-action-click="handleMessageActionClick"
-      :on-message-long-press="handleMessageLongPress"
-    />
-  </div>
+  <CourierInbox
+    :on-message-click="handleMessageClick"
+    :on-message-action-click="handleMessageActionClick"
+    :on-message-long-press="handleMessageLongPress"
+  />
 </template>

--- a/examples/vue/src/InboxCustomFeed.vue
+++ b/examples/vue/src/InboxCustomFeed.vue
@@ -49,7 +49,5 @@ const feeds: CourierInboxFeed[] = [
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox :feeds="feeds" />
-  </div>
+  <CourierInbox :feeds="feeds" />
 </template>

--- a/examples/vue/src/InboxCustomTabs.vue
+++ b/examples/vue/src/InboxCustomTabs.vue
@@ -28,7 +28,5 @@ const feeds: CourierInboxFeed[] = [
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox :feeds="feeds" />
-  </div>
+  <CourierInbox :feeds="feeds" />
 </template>

--- a/examples/vue/src/InboxDefault.vue
+++ b/examples/vue/src/InboxDefault.vue
@@ -23,7 +23,5 @@ onMounted(() => {
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox />
-  </div>
+  <CourierInbox />
 </template>

--- a/examples/vue/src/InboxTheme.vue
+++ b/examples/vue/src/InboxTheme.vue
@@ -162,7 +162,5 @@ const theme: CourierInboxTheme = {
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox :light-theme="theme" :dark-theme="theme" mode="light" />
-  </div>
+  <CourierInbox :light-theme="theme" :dark-theme="theme" mode="light" />
 </template>

--- a/examples/vue/src/MarkdownListItem.vue
+++ b/examples/vue/src/MarkdownListItem.vue
@@ -29,7 +29,5 @@ const renderListItem = (props: CourierInboxListItemFactoryProps | null | undefin
 </script>
 
 <template>
-  <div :style="{ padding: '24px' }">
-    <CourierInbox :render-list-item="renderListItem" />
-  </div>
+  <CourierInbox :render-list-item="renderListItem" />
 </template>


### PR DESCRIPTION
## What

Tidies the showcase example apps so the three SDK demos stay consistent:

- Removes the fixed `<div style={{ padding: '24px' }}>` wrapper around the showcase components
- Simplifies `InboxActions` and `MarkdownListItem`

Applied uniformly across `examples/react-17`, `examples/react-latest`, and `examples/vue`.

## Notes

- Example-only changes — no package source touched, no version bump, nothing published.
- 24 files changed (+72 / −120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)