### PR TITLE
test(vue,angular): add component tests to match courier-react parity

### DIFF
--- a/@trycourier/courier-angular/src/__mocks__/angular-core.ts
+++ b/@trycourier/courier-angular/src/__mocks__/angular-core.ts
@@ -1,12 +1,115 @@
 // `@angular/core` ships ESM-only (`.mjs`) bundles that Jest can't load as
-// CommonJS. The CourierService only needs the `Injectable` decorator at runtime
-// (and `OnDestroy` is an interface, erased at compile time), and the E2E tests
-// instantiate the service directly rather than through Angular's DI. So we stub
-// `@angular/core` with a no-op decorator instead of pulling in the full Angular
-// runtime (and zone.js / TestBed) just to exercise the service's logic.
+// CommonJS, and pulling in the full Angular runtime (zone.js / TestBed) just to
+// exercise our thin wrappers is heavy and brittle. So we stub `@angular/core`
+// with the minimum surface our code touches and drive components by direct
+// instantiation — the same approach the CourierService E2E tests use.
+//
+// For the service that means just the `Injectable` decorator. For the
+// components it additionally means: no-op class/property decorators, a real
+// `EventEmitter`, value tokens for `inject()`, and a tiny injection context the
+// tests populate before constructing a component (see `setInjectionContext`).
 
+/** No-op `@Injectable()` — DI metadata is irrelevant to direct instantiation. */
 export function Injectable(): ClassDecorator {
   return () => {
-    // no-op: DI metadata is irrelevant to direct instantiation
+    // no-op
   };
+}
+
+/** No-op `@Component({...})`. */
+export function Component(_config?: unknown): ClassDecorator {
+  return () => {
+    // no-op
+  };
+}
+
+/** No-op property decorators. */
+export function Input(): PropertyDecorator {
+  return () => {
+    // no-op
+  };
+}
+export function Output(): PropertyDecorator {
+  return () => {
+    // no-op
+  };
+}
+export function ContentChild(_selector: unknown, _opts?: unknown): PropertyDecorator {
+  return () => {
+    // no-op
+  };
+}
+
+/** Mirrors Angular's `ChangeDetectionStrategy` enum (only `OnPush` is referenced). */
+export const ChangeDetectionStrategy = { OnDefault: 1, OnPush: 0 } as const;
+
+/** Schema marker referenced in `@Component` metadata. */
+export const CUSTOM_ELEMENTS_SCHEMA = { name: "custom-elements" };
+
+/** Minimal `EventEmitter` — supports `.emit()` and `.subscribe()`. */
+export class EventEmitter<T> {
+  private listeners: Array<(value: T) => void> = [];
+
+  emit(value: T): void {
+    this.listeners.slice().forEach((listener) => listener(value));
+  }
+
+  subscribe(next: (value: T) => void): { unsubscribe: () => void } {
+    this.listeners.push(next);
+    return {
+      unsubscribe: () => {
+        this.listeners = this.listeners.filter((listener) => listener !== next);
+      },
+    };
+  }
+}
+
+// Injection tokens. These are referenced both as `inject(X)` arguments and as
+// types, so they must exist as runtime values.
+export class ElementRef<T = unknown> {
+  constructor(public nativeElement: T) {}
+}
+export class ViewContainerRef {}
+export class TemplateRef<C = unknown> {}
+
+// Type-only members — erased at compile time, declared so imports resolve.
+export interface EmbeddedViewRef<C> {
+  rootNodes: unknown[];
+  detectChanges(): void;
+  destroy(): void;
+}
+export interface AfterViewInit {
+  ngAfterViewInit(): void;
+}
+export interface OnChanges {
+  ngOnChanges(): void;
+}
+export interface OnDestroy {
+  ngOnDestroy(): void;
+}
+
+// --- Lightweight injection context used by tests -------------------------------
+// Components call `inject(ElementRef)` / `inject(ViewContainerRef)` in their field
+// initializers (the constructor). Tests set the active context immediately before
+// `new Component()`; `inject()` resolves tokens against it.
+
+let activeInjector: Map<unknown, unknown> | null = null;
+
+/** Sets the injection context resolved by `inject()` for the next construction. */
+export function setInjectionContext(providers: Map<unknown, unknown>): void {
+  activeInjector = providers;
+}
+
+/** Clears the active injection context. */
+export function clearInjectionContext(): void {
+  activeInjector = null;
+}
+
+export function inject<T>(token: unknown): T {
+  if (!activeInjector || !activeInjector.has(token)) {
+    throw new Error(
+      "inject() called outside of a test injection context. Wrap construction with setInjectionContext()."
+    );
+  }
+  return activeInjector.get(token) as T;
 }

--- a/@trycourier/courier-angular/src/__tests__/component-harness.ts
+++ b/@trycourier/courier-angular/src/__tests__/component-harness.ts
@@ -1,0 +1,74 @@
+// Import from the stub directly (not "@angular/core"): these helpers and the
+// simplified token/view types only exist in the mock. At runtime Jest maps
+// "@angular/core" to this same file, so `ElementRef`/`ViewContainerRef` here are
+// the exact identities the components resolve via `inject()`.
+import {
+  ElementRef,
+  ViewContainerRef,
+  clearInjectionContext,
+  setInjectionContext,
+  type EmbeddedViewRef,
+} from "../__mocks__/angular-core";
+
+/**
+ * Test harness for the Courier Angular components.
+ *
+ * The components resolve `ElementRef`/`ViewContainerRef` via `inject()` in their
+ * field initializers, so we populate the stubbed injection context immediately
+ * before construction (see `__mocks__/angular-core.ts`). This mirrors the
+ * "instantiate directly, no TestBed" approach the CourierService tests use, while
+ * still exercising the real `<courier-*>` web component as the host element.
+ */
+export function createComponent<T>(
+  Ctor: new () => T,
+  element: HTMLElement,
+  viewContainerRef: ViewContainerRef
+): T {
+  setInjectionContext(
+    new Map<unknown, unknown>([
+      [ElementRef, new ElementRef(element)],
+      [ViewContainerRef, viewContainerRef],
+    ])
+  );
+  try {
+    return new Ctor();
+  } finally {
+    clearInjectionContext();
+  }
+}
+
+export type FakeEmbeddedView = EmbeddedViewRef<unknown> & {
+  rootNodes: Node[];
+  detectChanges: jest.Mock;
+  destroy: jest.Mock;
+};
+
+/**
+ * A fake `ViewContainerRef` whose `createEmbeddedView` yields a view wrapping the
+ * nodes from `buildNodes()`. The returned `views` array records every view
+ * created so tests can assert teardown (`destroy`) on `ngOnDestroy`.
+ */
+export function createFakeViewContainerRef(buildNodes: () => Node[] = () => [document.createElement("div")]): {
+  viewContainerRef: ViewContainerRef;
+  views: FakeEmbeddedView[];
+} {
+  const views: FakeEmbeddedView[] = [];
+  const viewContainerRef = {
+    createEmbeddedView: () => {
+      const view: FakeEmbeddedView = {
+        rootNodes: buildNodes(),
+        detectChanges: jest.fn(),
+        destroy: jest.fn(),
+      };
+      views.push(view);
+      return view;
+    },
+  } as unknown as ViewContainerRef;
+
+  return { viewContainerRef, views };
+}
+
+/** Resolves after the next microtask, flushing a component's `queueMicrotask` work. */
+export function tick(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(() => resolve()));
+}

--- a/@trycourier/courier-angular/src/__tests__/courier-inbox.component.test.ts
+++ b/@trycourier/courier-angular/src/__tests__/courier-inbox.component.test.ts
@@ -1,0 +1,129 @@
+// Bare import for its side effect: registers the <courier-inbox> custom element.
+import "@trycourier/courier-ui-inbox";
+import {
+  CourierInbox as CourierInboxElement,
+  type CourierInboxListItemFactoryProps,
+} from "@trycourier/courier-ui-inbox";
+import { CourierInboxComponent } from "../components/courier-inbox.component";
+import { createComponent, createFakeViewContainerRef, tick, type FakeEmbeddedView } from "./component-harness";
+
+// Importing CourierInboxElement registers the <courier-inbox> custom element, so
+// document.createElement returns a real, upgraded instance to host the component.
+
+describe("CourierInboxComponent", () => {
+  let el: CourierInboxElement;
+
+  beforeEach(() => {
+    el = document.createElement("courier-inbox") as CourierInboxElement;
+    document.body.appendChild(el);
+    // Stub the element's event-registration API so the component wiring is
+    // exercised without depending on the element's internal behavior.
+    jest.spyOn(el, "onMessageClick").mockImplementation(() => {});
+    jest.spyOn(el, "onMessageActionClick").mockImplementation(() => {});
+    jest.spyOn(el, "onMessageLongPress").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    el.remove();
+    jest.restoreAllMocks();
+  });
+
+  describe("attributes", () => {
+    it("syncs inputs onto the host element after view init", async () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierInboxComponent, el, viewContainerRef);
+      component.height = "400px";
+      component.mode = "dark";
+      component.feeds = [{ id: "inbox", title: "Inbox", filters: {} }] as never;
+
+      component.ngAfterViewInit();
+      await tick();
+
+      expect(el.getAttribute("height")).toBe("400px");
+      expect(el.getAttribute("mode")).toBe("dark");
+      expect(JSON.parse(el.getAttribute("feeds")!)).toEqual([{ id: "inbox", title: "Inbox", filters: {} }]);
+    });
+
+    it("re-syncs attributes on ngOnChanges once ready", async () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierInboxComponent, el, viewContainerRef);
+      component.ngAfterViewInit();
+      await tick();
+
+      component.mode = "light";
+      component.ngOnChanges();
+
+      expect(el.getAttribute("mode")).toBe("light");
+    });
+
+    it("does not touch the element before ngAfterViewInit (ngOnChanges no-ops while not ready)", () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierInboxComponent, el, viewContainerRef);
+      component.mode = "dark";
+      component.ngOnChanges();
+
+      expect(el.hasAttribute("mode")).toBe(false);
+    });
+  });
+
+  describe("events", () => {
+    it("emits messageClick when the element invokes its registered handler", async () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierInboxComponent, el, viewContainerRef);
+
+      const emitted: CourierInboxListItemFactoryProps[] = [];
+      component.messageClick.subscribe((props) => emitted.push(props));
+
+      component.ngAfterViewInit();
+      await tick();
+
+      // The component registers a single handler; invoking it should fan out to
+      // the @Output EventEmitter.
+      const onMessageClick = el.onMessageClick as jest.Mock;
+      expect(onMessageClick).toHaveBeenCalledTimes(1);
+      const registered = onMessageClick.mock.calls[0][0];
+      const fakeProps = { message: { messageId: "m1" } } as CourierInboxListItemFactoryProps;
+      registered(fakeProps);
+
+      expect(emitted).toEqual([fakeProps]);
+    });
+  });
+
+  describe("custom render slots", () => {
+    it("bridges a header template to the element and tracks the view for teardown", async () => {
+      const clickHandler = jest.fn();
+      const setHeader = jest.spyOn(el, "setHeader").mockImplementation(() => {});
+      const { viewContainerRef, views } = createFakeViewContainerRef(() => {
+        const node = document.createElement("div");
+        node.id = "my-header";
+        node.textContent = "Custom Header";
+        node.addEventListener("click", clickHandler);
+        return [node];
+      });
+
+      const component = createComponent(CourierInboxComponent, el, viewContainerRef);
+      // Simulate Angular projecting `<ng-template #header>` into the @ContentChild.
+      component.headerTpl = {} as never;
+
+      component.ngAfterViewInit();
+      await tick();
+
+      expect(setHeader).toHaveBeenCalledTimes(1);
+
+      // Invoking the registered factory renders the template into a detached element.
+      const factory = setHeader.mock.calls[0][0] as (props: unknown) => HTMLElement;
+      const rendered = factory(null);
+      const header = rendered.querySelector("#my-header") as HTMLElement | null;
+
+      expect(header).toBeTruthy();
+      expect(header?.textContent).toBe("Custom Header");
+
+      header?.click();
+      expect(clickHandler).toHaveBeenCalled();
+
+      // The embedded view is destroyed on teardown to avoid leaks.
+      component.ngOnDestroy();
+      expect((views[0] as FakeEmbeddedView).destroy).toHaveBeenCalled();
+    });
+  });
+});

--- a/@trycourier/courier-angular/src/__tests__/courier-toast.component.test.ts
+++ b/@trycourier/courier-angular/src/__tests__/courier-toast.component.test.ts
@@ -1,0 +1,132 @@
+// Bare import for its side effect: registers the <courier-toast> custom element.
+import "@trycourier/courier-ui-toast";
+import {
+  CourierToast as CourierToastElement,
+  type CourierToastItemClickEvent,
+} from "@trycourier/courier-ui-toast";
+import { CourierToastComponent } from "../components/courier-toast.component";
+import { createComponent, createFakeViewContainerRef, tick, type FakeEmbeddedView } from "./component-harness";
+
+// Importing CourierToastElement registers the <courier-toast> custom element, so
+// document.createElement returns a real, upgraded instance to host the component.
+
+describe("CourierToastComponent", () => {
+  let el: CourierToastElement;
+
+  beforeEach(() => {
+    el = document.createElement("courier-toast") as CourierToastElement;
+    document.body.appendChild(el);
+    // Stub the element's event-registration API so the component wiring is
+    // exercised without depending on the element's internal behavior.
+    jest.spyOn(el, "onToastItemClick").mockImplementation(() => {});
+    jest.spyOn(el, "onToastItemActionClick").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    el.remove();
+    jest.restoreAllMocks();
+  });
+
+  describe("attributes", () => {
+    it("syncs inputs onto the host element after view init", async () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierToastComponent, el, viewContainerRef);
+      component.mode = "dark";
+      component.autoDismiss = true;
+      component.autoDismissTimeoutMs = 4000;
+      component.dismissButton = "visible";
+
+      component.ngAfterViewInit();
+      await tick();
+
+      expect(el.getAttribute("mode")).toBe("dark");
+      expect(el.getAttribute("auto-dismiss")).toBe("true");
+      expect(el.getAttribute("auto-dismiss-timeout-ms")).toBe("4000");
+      expect(el.getAttribute("dismiss-button")).toBe("visible");
+    });
+
+    it("re-syncs attributes on ngOnChanges once ready", async () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierToastComponent, el, viewContainerRef);
+      component.ngAfterViewInit();
+      await tick();
+
+      component.mode = "light";
+      component.ngOnChanges();
+
+      expect(el.getAttribute("mode")).toBe("light");
+    });
+  });
+
+  describe("readiness", () => {
+    it("emits ready$ exactly once after registering handlers", async () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierToastComponent, el, viewContainerRef);
+
+      const ready: boolean[] = [];
+      component.ready$.subscribe((value) => ready.push(value));
+
+      component.ngAfterViewInit();
+      await tick();
+
+      expect(ready).toEqual([true]);
+    });
+  });
+
+  describe("events", () => {
+    it("emits toastItemClick when the element invokes its registered handler", async () => {
+      const { viewContainerRef } = createFakeViewContainerRef();
+      const component = createComponent(CourierToastComponent, el, viewContainerRef);
+
+      const emitted: CourierToastItemClickEvent[] = [];
+      component.toastItemClick.subscribe((props) => emitted.push(props));
+
+      component.ngAfterViewInit();
+      await tick();
+
+      const onToastItemClick = el.onToastItemClick as jest.Mock;
+      expect(onToastItemClick).toHaveBeenCalledTimes(1);
+      const registered = onToastItemClick.mock.calls[0][0];
+      const fakeEvent = { message: { messageId: "m1" } } as CourierToastItemClickEvent;
+      registered(fakeEvent);
+
+      expect(emitted).toEqual([fakeEvent]);
+    });
+  });
+
+  describe("custom render slots", () => {
+    it("bridges a toast content template to the element and tracks the view for teardown", async () => {
+      const clickHandler = jest.fn();
+      const setToastItemContent = jest.spyOn(el, "setToastItemContent").mockImplementation(() => {});
+      const { viewContainerRef, views } = createFakeViewContainerRef(() => {
+        const node = document.createElement("div");
+        node.id = "my-toast-content";
+        node.textContent = "Custom Content";
+        node.addEventListener("click", clickHandler);
+        return [node];
+      });
+
+      const component = createComponent(CourierToastComponent, el, viewContainerRef);
+      // Simulate Angular projecting `<ng-template #toastItemContent>` into the @ContentChild.
+      component.toastItemContentTpl = {} as never;
+
+      component.ngAfterViewInit();
+      await tick();
+
+      expect(setToastItemContent).toHaveBeenCalledTimes(1);
+
+      const factory = setToastItemContent.mock.calls[0][0] as (props: unknown) => HTMLElement;
+      const rendered = factory(null);
+      const content = rendered.querySelector("#my-toast-content") as HTMLElement | null;
+
+      expect(content).toBeTruthy();
+      expect(content?.textContent).toBe("Custom Content");
+
+      content?.click();
+      expect(clickHandler).toHaveBeenCalled();
+
+      component.ngOnDestroy();
+      expect((views[0] as FakeEmbeddedView).destroy).toHaveBeenCalled();
+    });
+  });
+});

--- a/@trycourier/courier-vue/src/__tests__/courier-toast.test.ts
+++ b/@trycourier/courier-vue/src/__tests__/courier-toast.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { h } from "vue";
+// Import from the package entry so the web component is registered (the entry's
+// re-exports from courier-ui-toast trigger registerElement), mirroring how
+// consumers import the SDK.
+import { CourierToast } from "../index";
+import { CourierToast as CourierToastElement } from "@trycourier/courier-ui-toast";
+
+// Wait for onMounted + queueMicrotask readiness, then any pending render work.
+async function settle() {
+  await flushPromises();
+  await new Promise((resolve) => queueMicrotask(() => resolve(null)));
+  await flushPromises();
+}
+
+describe("CourierToast", () => {
+  it("renders the underlying <courier-toast> custom element", async () => {
+    const wrapper = mount(CourierToast, { attachTo: document.body });
+    await settle();
+
+    expect(wrapper.find("courier-toast").exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("syncs props onto the element as attributes", async () => {
+    const wrapper = mount(CourierToast, {
+      attachTo: document.body,
+      props: {
+        mode: "dark",
+        autoDismiss: true,
+        autoDismissTimeoutMs: 4000,
+        dismissButton: "visible",
+      },
+    });
+    await settle();
+
+    const el = wrapper.find("courier-toast").element;
+    expect(el.getAttribute("mode")).toBe("dark");
+    expect(el.hasAttribute("auto-dismiss")).toBe(true);
+    expect(el.getAttribute("auto-dismiss-timeout-ms")).toBe("4000");
+    expect(el.getAttribute("dismiss-button")).toBe("visible");
+
+    wrapper.unmount();
+  });
+
+  it("exposes the underlying element via getElement()", async () => {
+    const wrapper = mount(CourierToast, { attachTo: document.body });
+    await settle();
+
+    const el = (wrapper.vm as unknown as { getElement: () => CourierToastElement | null }).getElement();
+    expect(el).toBeTruthy();
+    expect(typeof el?.setToastItem).toBe("function");
+
+    wrapper.unmount();
+  });
+
+  it("registers custom toast content via the render bridge and signals readiness once", async () => {
+    const setToastItemContentSpy = vi.spyOn(CourierToastElement.prototype, "setToastItemContent");
+    const onReady = vi.fn();
+
+    const wrapper = mount(CourierToast, {
+      attachTo: document.body,
+      props: {
+        onReady,
+        renderToastItemContent: () => h("div", { id: "my-toast-content" }, "Custom Content"),
+      },
+    });
+    await settle();
+
+    // The render prop is bridged through to the element's content factory exactly
+    // once, and readiness is signalled a single time (no duplicate registrations).
+    expect(setToastItemContentSpy).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledWith(true);
+
+    setToastItemContentSpy.mockRestore();
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## What

Brings the **Vue** and **Angular** kits up to the unit-test bar already set by **courier-react**. Both kits ship the same components as React but were missing the component-level integration tests.

### Gap closed

| React test | Before | After |
|---|---|---|
| `courier-toast` integration | ❌ Vue, ❌ Angular | ✅ Vue, ✅ Angular |
| `courier-inbox` integration | ❌ Angular | ✅ Angular |

### New tests
- **courier-vue** — `CourierToast`: renders `<courier-toast>`, syncs props→attributes, exposes `getElement()`, bridges `renderToastItemContent` and signals `onReady` once. Mirrors React's `courier-toast.test.tsx`.
- **courier-angular** — `CourierInbox` + `CourierToast`: attribute sync, `ngOnChanges` re-sync (and no-op before ready), `@Output` emission (`messageClick` / `toastItemClick`), `ready$` emits once, and custom render-template bridging with embedded-view teardown.

## How (Angular)

The Angular kit deliberately avoids the ESM-only Angular runtime (no zone.js/TestBed) — see the existing `CourierService` E2E test, which instantiates directly. These component tests follow the same approach:

- A small `component-harness.ts` constructs components with a stubbed injection context and a fake `ViewContainerRef`, while hosting the **real** `<courier-*>` web component as the element.
- The `@angular/core` mock is expanded minimally (no-op decorators, a real `EventEmitter`, `inject()` + a tiny test injection context, value tokens).

> If we later want full-fidelity component rendering, that'd be a separate `jest-preset-angular` + `TestBed` infra change.

## Test results
All 14 new cases pass. The pre-existing live E2E suites (`courier.service.test.ts`, `use-courier.test.ts`) still require `USER_ID`/`JWT` credentials and are unaffected by this change.

Build/publish unaffected — new files live under `src/__tests__` / `src/__mocks__`, which both package builds already exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)