### PR TITLE
fix(preferences): keep heading/description when there are no topics

### DIFF
--- a/@trycourier/courier-ui-preferences/src/components/__tests__/courier-preferences.test.ts
+++ b/@trycourier/courier-ui-preferences/src/components/__tests__/courier-preferences.test.ts
@@ -87,6 +87,50 @@ describe("courier-preferences channel labels", () => {
   });
 });
 
+describe("courier-preferences header with no topics", () => {
+  afterEach(() => {
+    while (document.body.firstChild) {
+      document.body.firstChild.remove();
+    }
+  });
+
+  function mount(): CourierPreferences {
+    const el = new CourierPreferences();
+    document.body.appendChild(el);
+    return el;
+  }
+
+  /** An empty page (no sections) that still carries a heading + description. */
+  function emptyPageWithHeader(): CourierPreferencePage {
+    return {
+      showCourierFooter: false,
+      heading: "Notification Preferences",
+      description: "Choose how you'd like to be notified.",
+      sections: [],
+      recipientPreferences: [],
+    } as unknown as CourierPreferencePage;
+  }
+
+  it("still renders the heading and description when there are no topics", () => {
+    const el = mount();
+    el.setPreviewData(emptyPageWithHeader());
+
+    const title = document.querySelector<HTMLElement>(
+      ".courier-preferences-header-title"
+    );
+    const subtitle = document.querySelector<HTMLElement>(
+      ".courier-preferences-header-subtitle"
+    );
+    expect(title?.textContent).toBe("Notification Preferences");
+    expect(subtitle?.textContent).toBe(
+      "Choose how you'd like to be notified."
+    );
+
+    // The empty state renders alongside the header (not in place of it).
+    expect(document.body.textContent).toContain("No preferences available");
+  });
+});
+
 describe("courier-preferences preview state preservation", () => {
   // jsdom doesn't implement CSS.escape, which the in-place topic update uses to
   // build a selector. A minimal pass-through keeps the topic ids in this suite

--- a/@trycourier/courier-ui-preferences/src/components/courier-preferences.ts
+++ b/@trycourier/courier-ui-preferences/src/components/courier-preferences.ts
@@ -734,17 +734,11 @@ export class CourierPreferences extends CourierBaseElement {
       return;
     }
 
-    // Empty (loading complete, no error, no sections)
-    if (!this._isLoading && !this._error && this._sections.length === 0) {
-      inner.appendChild(this._buildEmptyState());
-      root.appendChild(inner);
-      this.appendChild(root);
-      return;
-    }
-
     // Header (optional title / subtitle above the sections). The `title` /
     // `subtitle` attributes set by the host take precedence; otherwise fall back
-    // to the workspace-configured page heading / description.
+    // to the workspace-configured page heading / description. Rendered before the
+    // empty-state check (but after error/loading, which still return early) so a
+    // configured heading/description still shows when there are no topics yet.
     const headerTitle = this._title ?? this._pageHeading;
     const headerSubtitle = this._subtitle ?? this._pageDescription;
     if (headerTitle || headerSubtitle) {
@@ -777,6 +771,15 @@ export class CourierPreferences extends CourierBaseElement {
         header.appendChild(subtitleEl);
       }
       inner.appendChild(header);
+    }
+
+    // Empty (loading complete, no error, no sections). The header above still
+    // renders, so the page keeps its heading/description with an empty body.
+    if (!this._isLoading && !this._error && this._sections.length === 0) {
+      inner.appendChild(this._buildEmptyState());
+      root.appendChild(inner);
+      this.appendChild(root);
+      return;
     }
 
     // Sections


### PR DESCRIPTION
## What

The `<CourierPreferences>` component rendered **only** the empty state (and returned early) when there were no sections — *before* the header. So a page with a configured heading/description but no topics collapsed to a bare "No preferences available", dropping its title/subtitle.

This moves the empty-state check to **after** the header render, so the heading/description (host `title`/`subtitle`, falling back to the workspace page heading/description) still show above the empty state.

- Error / loading still return early as before — only the empty-with-no-topics case changes.

## Test

Adds a `"header with no topics"` suite: mounts the component with an empty page that carries a heading + description, asserts both the header title/subtitle render **and** that "No preferences available" still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)