### PR TITLE
chore: cut release — preferences preview-data + vue/angular republish

### DIFF
--- a/.agents/skills/changesets/SKILL.md
+++ b/.agents/skills/changesets/SKILL.md
@@ -51,7 +51,7 @@ Add getUnreadCounts API and expose it through useCourier hook
 
 ### Valid package names
 
-`@trycourier/courier-js` · `@trycourier/courier-react` · `@trycourier/courier-react-17` · `@trycourier/courier-react-components` · `@trycourier/courier-ui-core` · `@trycourier/courier-ui-inbox` · `@trycourier/courier-ui-toast` · `@trycourier/courier-ui-preferences`
+`@trycourier/courier-js` · `@trycourier/courier-react` · `@trycourier/courier-react-17` · `@trycourier/courier-react-components` · `@trycourier/courier-ui-core` · `@trycourier/courier-ui-inbox` · `@trycourier/courier-ui-toast` · `@trycourier/courier-ui-preferences` · `@trycourier/courier-vue` · `@trycourier/courier-angular`
 
 Internal dependents are bumped automatically at release time (`updateInternalDependencies: patch`), so only list packages whose own source you changed.
 

--- a/.changeset/brave-foxes-wander.md
+++ b/.changeset/brave-foxes-wander.md
@@ -1,0 +1,6 @@
+---
+"@trycourier/courier-vue": patch
+"@trycourier/courier-angular": patch
+---
+
+Republish with corrected packaging: publish the ng-packagr dist output via `publishConfig.directory` (angular) and keep test files out of the published package (vue). The 1.0.0 release predated these fixes.

--- a/.changeset/quiet-otters-gather.md
+++ b/.changeset/quiet-otters-gather.md
@@ -1,0 +1,10 @@
+---
+"@trycourier/courier-js": minor
+"@trycourier/courier-ui-preferences": minor
+"@trycourier/courier-ui-inbox": patch
+"@trycourier/courier-react-components": patch
+"@trycourier/courier-ui-toast": patch
+"@trycourier/courier-react": patch
+---
+
+Preferences: preview-data, draft mode, descriptions, and digest schedules (with DST handling); inbox preview support and "In-App" channel label fix; toast linear timing. Adds the supporting preview-data/draft preference and inbox API surface to courier-js.


### PR DESCRIPTION
## Why

Source has been merging to `main` since the **2026-06-18** release without changesets, so nothing has published to npm since then. This adds the retroactive changesets so the changesets bot opens a **Version Packages** PR and the following ships:

| Package | Current (npm) | Bump | Target |
|---|---|---|---|
| `@trycourier/courier-ui-preferences` | 1.1.1 | minor | **1.2.0** |
| `@trycourier/courier-js` | 3.4.0 | minor | **3.5.0** |
| `@trycourier/courier-ui-inbox` | 2.4.8 | patch | **2.4.9** |
| `@trycourier/courier-react-components` | 2.2.3 | patch | **2.2.4** |
| `@trycourier/courier-ui-toast` | 2.1.7 | patch | **2.1.8** |
| `@trycourier/courier-react` | 9.2.3 | patch | **9.2.4** |
| `@trycourier/courier-react-17` | 9.2.3 | patch¹ | **9.2.4** |
| `@trycourier/courier-vue` | 1.0.0 | patch | **1.0.1** |
| `@trycourier/courier-angular` | 1.0.0 | patch | **1.0.1** |

¹ internal-dependency cascade.

### What's being released
- **Preferences** (#195/#208/#209): preview-data, draft mode, descriptions, digest schedules (DST), plus the "In-App" inbox label fix and inbox preview.
- **courier-js**: supporting preview-data/draft preference + inbox API surface.
- **courier-vue / courier-angular**: republish at 1.0.1 — the 1.0.0 npm release predates the ng-packagr `publishConfig.directory` fix (#68a9321) and the "keep test files out of dist" fix (#00bdbae), which were never republished.

### Also
- Adds `@trycourier/courier-vue` and `@trycourier/courier-angular` to the **changesets skill**'s valid-package list (they were missing).

## Merge flow
1. Merge this PR → `Release` workflow runs → changesets bot opens a **Version Packages** PR.
2. Merge that PR → `yarn release` publishes to npm + tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)