### PR TITLE
fix(ci): run Release job on Node 24 (npm@latest v12 dropped Node 20)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       # OIDC requires npm 11.5.1 or later
       # Changesets calls npm to publish packages


### PR DESCRIPTION
## What's going on

The **Release** workflow started failing at the `Update npm` step:

```
npm error code EBADENGINE
npm error notsup Not compatible with your version of node/npm: npm@12.0.0
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

`npm install -g npm@latest` now pulls **npm@12.0.0**, which dropped support for Node 20. The job pins **Node 20**, so bootstrap fails and `changesets/action` never runs. This is unrelated to any merged change — it broke the moment npm published 12.0.0, and blocks *all* releases.

Failed run: https://github.com/trycourier/courier-web/actions/runs/29050626165

## Fix

Bump the Release job from Node 20 → **Node 24.x** (satisfies npm@12's `^24.15.0`). Also clears the "Node 20 is deprecated" annotation.

## After merge

The pending release changesets from #210 (`courier-ui-preferences` 1.2.0, `courier-js` 3.5.0, `courier-ui-inbox` 2.4.9, `courier-ui-toast` 2.1.8, `courier-react`/`courier-react-17` 9.2.4, `courier-react-components` 2.2.4, `courier-vue`/`courier-angular` 1.0.1) are already on `main`. Once this merges and the Release workflow runs green, `changesets/action` will open the **Version Packages** PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)