### PR TITLE
fix(preferences): pluralize digest schedule labels

### DIFF
--- a/@trycourier/courier-ui-preferences/src/utils/__tests__/format-digest.test.ts
+++ b/@trycourier/courier-ui-preferences/src/utils/__tests__/format-digest.test.ts
@@ -56,7 +56,7 @@ describe("format-digest", () => {
             on: { friday: true, monday: true, wednesday: true },
           },
         });
-        expect(formatDigest(schedule)).toBe("Every 1 week(s) on Monday, Wednesday, Friday");
+        expect(formatDigest(schedule)).toBe("Every week on Monday, Wednesday, Friday");
       });
 
       it("uses a string day-of-week when `on` is a string", () => {
@@ -65,7 +65,7 @@ describe("format-digest", () => {
           recurrence: "custom",
           repeat: { frequency: 2, interval: "week", on: "Tuesday" },
         });
-        expect(formatDigest(schedule)).toBe("Every 2 week(s) on Tuesday");
+        expect(formatDigest(schedule)).toBe("Every 2 weeks on Tuesday");
       });
 
       it("describes a monthly day-of-month", () => {
@@ -74,7 +74,7 @@ describe("format-digest", () => {
           recurrence: "custom",
           repeat: { frequency: 1, interval: "month", on: "1st" },
         });
-        expect(formatDigest(schedule)).toBe("Every 1 month(s) on 1st of the month");
+        expect(formatDigest(schedule)).toBe("Every month on 1st of the month");
       });
 
       it("appends a numeric occurrence count from `end`", () => {
@@ -84,7 +84,7 @@ describe("format-digest", () => {
           end: 5,
           repeat: { frequency: 1, interval: "week", on: "Monday" },
         });
-        expect(formatDigest(schedule)).toBe("Every 1 week(s) on Monday (5 occurrences)");
+        expect(formatDigest(schedule)).toBe("Every week on Monday (5 occurrences)");
       });
 
       it("appends an end date from a string `end`", () => {
@@ -95,7 +95,7 @@ describe("format-digest", () => {
           repeat: { frequency: 1, interval: "day" },
         });
         const result = formatDigest(schedule);
-        expect(result).toContain("Every 1 day(s)");
+        expect(result).toContain("Every day");
         expect(result).toContain("(until ");
       });
 

--- a/@trycourier/courier-ui-preferences/src/utils/format-digest.ts
+++ b/@trycourier/courier-ui-preferences/src/utils/format-digest.ts
@@ -64,7 +64,11 @@ function getWeekdaysString(repeatOn: Record<string, boolean>): string {
 function getScheduleString(schedule: DigestSchedule): string {
   if (schedule.recurrence === "custom" && schedule.repeat) {
     const { frequency, interval, on } = schedule.repeat;
-    let str = `Every ${frequency} ${interval}(s)`;
+    // "Every week", "Every 2 weeks" — the count only reads well when > 1.
+    let str =
+      frequency === 1
+        ? `Every ${interval}`
+        : `Every ${frequency} ${interval}s`;
 
     if (interval === "week" && on && typeof on === "object") {
       str += ` on ${getWeekdaysString(on as Record<string, boolean>)}`;


### PR DESCRIPTION
## Summary
- `formatDigest` rendered custom recurrences as `Every 1 week(s)` — the frequency now drops for singular ("Every week on Monday") and pluralizes properly above one ("Every 2 weeks on Tuesday").
- Applies to every custom-recurrence interval (day/week/month/year).
- Updated the 5 test assertions covering these strings; all 49 package tests pass.

Surfaces affected: the `<courier-preferences>` digest schedule picker (studio live preview + hosted preferences page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)