### PR TITLE
fix(toast): subtle border + softer dark-mode hover on toast items

### DIFF
--- a/.agents/skills/update-component-theme/SKILL.md
+++ b/.agents/skills/update-component-theme/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: update-component-theme
+description: Change or add a themable style (border, color, shadow, radius, font) on a Courier UI web component — inbox, toast, preferences, or core. Use when adjusting a component's default look, adding a new theme property, or fixing a style that doesn't render in light or dark mode.
+---
+
+# Update a component theme property
+
+The `@trycourier/courier-ui-*` packages style their web components through a theme object, not per-element CSS. Every default style change touches the same few places; this skill walks them in order.
+
+## Where things live
+
+For a package `<pkg>` (e.g. `courier-ui-toast`):
+
+| What | Where |
+| --- | --- |
+| Theme types + defaults | `@trycourier/<pkg>/src/types/<component>-theme.ts` — `defaultLightTheme`, `defaultDarkTheme`, `mergeTheme` |
+| CSS that consumes the theme | The component's `getStyles(theme)` (e.g. `src/components/courier-toast.ts`) — styles are injected globally, keyed by element id |
+| Color palette | `@trycourier/courier-ui-core/src/utils/courier-colors.ts` (`CourierColors`) |
+
+## Rules of thumb
+
+1. **Pick colors from `CourierColors`** — don't introduce new hex values. Conventions used across inbox/toast:
+   - Light-mode borders: `CourierColors.gray[500]` (`#E5E5E5`)
+   - Dark-mode borders: `CourierColors.gray[400]` (`#3A3A3A`)
+   - Backgrounds: `white[500]` (light) / `black[500]` (dark)
+2. **Check contrast against the background.** A default that equals the background color renders invisible (this happened with the toast item's dark border, which was `black[500]` on a `black[500]` background). Assert in a test that the new value differs from `backgroundColor`.
+3. **New theme property?** Add it to the theme type, both default themes, `mergeTheme` (nested objects need their own spread there — flat props merge automatically), and the component's `getStyles`. Existing property? Only the default values change.
+4. **Public type changed?** Regenerate API reports (see the [api-reports](../api-reports/SKILL.md) skill). Value-only changes don't touch the API report.
+
+## Verify
+
+- **Unit test** the defaults in `src/types/__tests__/` and run the package suite (see [run-tests](../run-tests/SKILL.md)):
+  ```bash
+  yarn workspace @trycourier/<pkg> run test
+  ```
+- **Visually** via the `web-js` example app (see [run-example-app](../run-example-app/SKILL.md)) — it aliases packages to `src/`, so no rebuild is needed. Toasts/inbox items can be spawned **without auth** from the console:
+  ```js
+  CourierToastDatastore.shared.addMessage({ messageId: "1", title: "Hi", body: "Test" });
+  ```
+  Check **both modes** — set `mode="light"` / `mode="dark"` on the element (the style refresh is async; re-read computed styles after ~300ms).
+
+## Ship
+
+1. Add a changeset — patch for default-value tweaks, minor for new theme properties (see [changesets](../changesets/SKILL.md)).
+2. Update docs: the component docs live in **mintlify-docs** (`sdk-libraries/courier-ui-inbox-web.mdx` covers inbox, toast, and preferences; theme types appear in `<Expandable>` blocks). Package READMEs between the `AUTO-GENERATED-OVERVIEW` markers are synced from mintlify-docs `sdk-libraries/readme-exports/` — never hand-edit those sections.
+3. Keep default-value changes and screenshots (light + dark) in the PR description so reviewers can see the before/after.

--- a/.changeset/brave-toads-shine.md
+++ b/.changeset/brave-toads-shine.md
@@ -1,5 +1,6 @@
 ---
+"@trycourier/courier-ui-core": minor
 "@trycourier/courier-ui-toast": patch
 ---
 
-Give toast items a visible subtle border in dark mode. The default dark theme border color was the same as the toast background, so no border was rendered; it now uses the same subtle gray as other Courier components.
+Toast items now render a visible subtle border in dark mode (the previous default matched the background color, so no border appeared), and the dark-mode hover/active backgrounds are softer, matching the inbox list item's effective hover colors. Adds opaque dark-surface shades `gray[700]`/`gray[800]` to `CourierColors`.

--- a/.changeset/brave-toads-shine.md
+++ b/.changeset/brave-toads-shine.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/courier-ui-toast": patch
+---
+
+Give toast items a visible subtle border in dark mode. The default dark theme border color was the same as the toast background, so no border was rendered; it now uses the same subtle gray as other Courier components.

--- a/@trycourier/courier-ui-core/src/utils/courier-colors.ts
+++ b/@trycourier/courier-ui-core/src/utils/courier-colors.ts
@@ -22,6 +22,11 @@ export const CourierColors = {
     400: '#3A3A3A',
     500: '#E5E5E5',
     600: '#737373',
+    // Opaque equivalents of white[500_20]/white[500_10] over black[500], for
+    // hover/active states on floating surfaces where a translucent overlay
+    // would let page content bleed through (e.g. toasts).
+    700: '#454545',
+    800: '#2E2E2E',
   },
   white: {
     500: '#FFFFFF',

--- a/@trycourier/courier-ui-toast/src/types/__tests__/courier-toast-theme.test.ts
+++ b/@trycourier/courier-ui-toast/src/types/__tests__/courier-toast-theme.test.ts
@@ -1,0 +1,18 @@
+import { defaultDarkTheme, defaultLightTheme } from "../courier-toast-theme";
+import { CourierColors } from "@trycourier/courier-ui-core";
+
+describe("default toast themes", () => {
+  it("light theme has a subtle border on the toast item", () => {
+    expect(defaultLightTheme.item?.border).toBe(`1px solid ${CourierColors.gray[500]}`);
+  });
+
+  it("dark theme has a subtle border on the toast item", () => {
+    expect(defaultDarkTheme.item?.border).toBe(`1px solid ${CourierColors.gray[400]}`);
+  });
+
+  it("borders are visible against the toast item background", () => {
+    for (const theme of [defaultLightTheme, defaultDarkTheme]) {
+      expect(theme.item?.border).not.toContain(theme.item?.backgroundColor as string);
+    }
+  });
+});

--- a/@trycourier/courier-ui-toast/src/types/__tests__/courier-toast-theme.test.ts
+++ b/@trycourier/courier-ui-toast/src/types/__tests__/courier-toast-theme.test.ts
@@ -10,6 +10,11 @@ describe("default toast themes", () => {
     expect(defaultDarkTheme.item?.border).toBe(`1px solid ${CourierColors.gray[400]}`);
   });
 
+  it("dark theme hover and active states are subtle opaque grays", () => {
+    expect(defaultDarkTheme.item?.hoverBackgroundColor).toBe(CourierColors.gray[800]);
+    expect(defaultDarkTheme.item?.activeBackgroundColor).toBe(CourierColors.gray[700]);
+  });
+
   it("borders are visible against the toast item background", () => {
     for (const theme of [defaultLightTheme, defaultDarkTheme]) {
       expect(theme.item?.border).not.toContain(theme.item?.backgroundColor as string);

--- a/@trycourier/courier-ui-toast/src/types/courier-toast-theme.ts
+++ b/@trycourier/courier-ui-toast/src/types/courier-toast-theme.ts
@@ -84,8 +84,8 @@ export const defaultLightTheme: CourierToastTheme = {
 export const defaultDarkTheme: CourierToastTheme = {
   item: {
     backgroundColor: CourierColors.black[500],
-    hoverBackgroundColor: CourierColors.gray[400],
-    activeBackgroundColor: CourierColors.gray[600],
+    hoverBackgroundColor: CourierColors.gray[800],
+    activeBackgroundColor: CourierColors.gray[700],
     shadow: `0px 4px 8px -2px ${CourierColors.gray[400]}`,
     border: `1px solid ${CourierColors.gray[400]}`,
     borderRadius: '8px',

--- a/@trycourier/courier-ui-toast/src/types/courier-toast-theme.ts
+++ b/@trycourier/courier-ui-toast/src/types/courier-toast-theme.ts
@@ -87,7 +87,7 @@ export const defaultDarkTheme: CourierToastTheme = {
     hoverBackgroundColor: CourierColors.gray[400],
     activeBackgroundColor: CourierColors.gray[600],
     shadow: `0px 4px 8px -2px ${CourierColors.gray[400]}`,
-    border: `1px solid ${CourierColors.black[500]}`,
+    border: `1px solid ${CourierColors.gray[400]}`,
     borderRadius: '8px',
     title: {
       size: '11pt',

--- a/api/courier-ui-core.api.md
+++ b/api/courier-ui-core.api.md
@@ -156,6 +156,8 @@ export const CourierColors: {
         400: string;
         500: string;
         600: string;
+        700: string;
+        800: string;
     };
     white: {
         500: string;


### PR DESCRIPTION
## What

Gives toast items a clean, subtle border in both theme modes and softens the dark-mode hover/active states to match the inbox list item.

**Border** — the dark default was `1px solid #171717` (`black[500]`), identical to the toast item's background, so no border rendered in dark mode. It now uses `gray[400]` (`#3A3A3A`), the same dark-mode border color the inbox components use. Light mode already followed the convention (`gray[500]`, `#E5E5E5`) and is unchanged.

**Hover/active (dark mode)** — hover was brighter than the inbox list item's, and active used `gray[600]` (`#737373`, the dark-mode body-text color). The inbox uses translucent white overlays (`white[500_10]`/`white[500_20]`), which the floating toast can't (a translucent hover background lets page content bleed through), so this adds their opaque pre-composited equivalents over `black[500]` to `CourierColors` — `gray[800]` (`#2E2E2E`) and `gray[700]` (`#454545`) — and uses them for toast hover/active.

| Mode | State | Before | After |
| --- | --- | --- | --- |
| Light | border | `1px solid #E5E5E5` | unchanged |
| Dark | border | `1px solid #171717` (invisible) | `1px solid #3A3A3A` |
| Dark | hover | `#3A3A3A` | `#2E2E2E` (matches inbox effective hover) |
| Dark | active | `#737373` | `#454545` (matches inbox effective active) |

## Also in this PR

- Default-theme tests (`courier-toast-theme.test.ts`) pinning the borders, dark hover/active, and asserting border color ≠ background color.
- A `.agents/skills/update-component-theme` skill documenting the workflow for themable style changes (theme defaults, `CourierColors` conventions, verification via the web-js example, changesets, docs sync).
- Regenerated `api/courier-ui-core.api.md` for the new palette shades.
- Changeset: minor bump for `@trycourier/courier-ui-core` (new palette shades), patch for `@trycourier/courier-ui-toast`.

## Verification

- `yarn workspace @trycourier/courier-ui-toast run test` — 54 passed.
- Verified live in the `web-js` example (`toast-basic.html`), computed styles:
  - dark rest: `rgb(23, 23, 23)` bg, `1px solid rgb(58, 58, 58)` border
  - dark hover: `rgb(46, 46, 46)` bg (border unchanged)
  - light: white bg, `1px solid rgb(229, 229, 229)` border

Docs note for the default border is in trycourier/mintlify-docs#608 (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
