### PR TITLE
fix(release): remove publish-time prepare rebuilds so npm publishing is race-free

### DIFF
--- a/.agents/skills/changesets/SKILL.md
+++ b/.agents/skills/changesets/SKILL.md
@@ -94,7 +94,7 @@ yarn changeset version
 
 - Show `git status` / `git diff --stat`.
 - If the public API surface changed, refresh the API reports (see the `api-reports` skill / `yarn generate-api-docs`).
-- The release itself runs in CI when the bump lands on `main` (`yarn release` builds and `changeset publish`es to npm).
+- The release itself runs in CI when the bump lands on `main` (`yarn release` builds and `changeset publish`es to npm). If that run fails or packages don't appear on npm, see the [npm-release-pipeline](../npm-release-pipeline/SKILL.md) skill.
 - Do **not** commit, push, or publish unless the user asks.
 
 ---

--- a/.agents/skills/npm-release-pipeline/SKILL.md
+++ b/.agents/skills/npm-release-pipeline/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: npm-release-pipeline
+description: Diagnose and drive the courier-web npm release pipeline — the Release workflow on main, the changesets "Version Packages" PR (changelogs + version bumps), and OIDC publishing to npm. Use when a Release run fails, packages didn't appear on npm after merging Version Packages, publishing hits ENEEDAUTH, or someone asks why the changelogs/release didn't kick off after a merge.
+---
+
+# npm release pipeline
+
+How a merged PR becomes an npm release. This is the courier-web (changesets) pipeline — **not** the api-spec/Stainless SDK pipeline, which is a separate release train with its own shepherding.
+
+## The happy path
+
+1. A PR that changes `@trycourier/*/src` ships a changeset (see the [changesets](../changesets/SKILL.md) skill).
+2. On every push to `main`, the **Release** workflow (`.github/workflows/release.yml`) runs the changesets action:
+   - **Changesets pending** → it creates/updates the **Version Packages** PR: applies the bumps, cascades internal deps, writes each `CHANGELOG.md`, deletes the consumed changesets. Changelogs only "kick off" through this PR — nothing publishes yet.
+   - **No changesets pending** (i.e. the push *is* the Version Packages merge) → it publishes: `yarn release` = `build-packages:ci` (topological build + API report check) then `changeset publish`.
+3. Publishing authenticates via **npm OIDC trusted publishing** (`id-token: write`, no NPM_TOKEN). Every package must be registered on npmjs.com: package → Settings → Trusted Publisher → GitHub Actions, repository `trycourier/courier-web`, workflow `release.yml`. Registration is per-package and can only be done by an npm owner.
+
+So the full release is **two merges**: the feature PR, then the Version Packages PR it spawns.
+
+## Triage a failed Release run
+
+```bash
+gh run list --repo trycourier/courier-web --workflow=release.yml --limit 5
+gh run view <run-id> --repo trycourier/courier-web --log-failed | grep -E "ENEEDAUTH|cannot publish|error|🦋" | head -50
+```
+
+A run can fail while still publishing most packages — always check the `🦋 packages published successfully:` / `🦋 packages failed to publish:` lists near the end, then confirm reality against the registry:
+
+```bash
+npm view @trycourier/<pkg> version
+```
+
+| Log signature | Meaning | Fix |
+| --- | --- | --- |
+| `ENEEDAUTH … requires you to be logged in` | That package isn't registered for OIDC trusted publishing on npmjs.com | An npm owner registers it (see above), then re-run |
+| `cannot publish over the previously published versions: X` | The version is already live; changesets' `npm info` check read a stale registry copy (common minutes after another run published it) | Benign — verify with `npm view`, then ignore or re-run later |
+| A package's build fails (`TS2307` etc.) *during publish* only | Something reintroduced per-package `prepare`/`prepublishOnly` build scripts. `changeset publish` runs all packages **concurrently**, so publish-time rebuilds race each other's `dist` | Keep packages free of publish-time build scripts — `build-packages:ci` in `yarn release` already builds everything topologically |
+| Whole run fails before any 🦋 output | `build-packages:ci` failed (build or stale API report) | See the [api-reports](../api-reports/SKILL.md) skill |
+
+## Re-kick a release
+
+Re-running is safe and idempotent — `changeset publish` only attempts versions missing from the registry:
+
+```bash
+gh run rerun <run-id> --repo trycourier/courier-web --failed
+```
+
+Or land the fix on `main`; the next push re-runs the whole flow.

--- a/@trycourier/courier-js/package.json
+++ b/@trycourier/courier-js/package.json
@@ -12,7 +12,6 @@
     "watch": "vite build --watch",
     "preview": "vite preview",
     "test": "jest",
-    "prepare": "npm run build",
     "generate-api-doc": "api-extractor run"
   },
   "keywords": [

--- a/@trycourier/courier-react-17/package.json
+++ b/@trycourier/courier-react-17/package.json
@@ -11,7 +11,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
     "generate-api-doc": "api-extractor run"

--- a/@trycourier/courier-react-components/package.json
+++ b/@trycourier/courier-react-components/package.json
@@ -13,7 +13,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "echo \"courier-react-components has no tests\"",
     "generate-api-doc": "api-extractor run"
   },

--- a/@trycourier/courier-react/package.json
+++ b/@trycourier/courier-react/package.json
@@ -11,7 +11,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "jest",
     "test:watch": "jest --watch",
     "generate-api-doc": "api-extractor run"

--- a/@trycourier/courier-ui-core/package.json
+++ b/@trycourier/courier-ui-core/package.json
@@ -11,7 +11,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "echo \"courier-ui-core has no tests\"",
     "generate-api-doc": "api-extractor run"
   },

--- a/@trycourier/courier-ui-inbox/package.json
+++ b/@trycourier/courier-ui-inbox/package.json
@@ -11,7 +11,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "jest",
     "generate-api-doc": "api-extractor run"
   },

--- a/@trycourier/courier-ui-preferences/package.json
+++ b/@trycourier/courier-ui-preferences/package.json
@@ -11,7 +11,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "jest",
     "generate-api-doc": "api-extractor run"
   },

--- a/@trycourier/courier-ui-toast/package.json
+++ b/@trycourier/courier-ui-toast/package.json
@@ -11,7 +11,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "jest",
     "generate-api-doc": "api-extractor run"
   },

--- a/@trycourier/courier-vue/package.json
+++ b/@trycourier/courier-vue/package.json
@@ -11,7 +11,6 @@
     "build:ci": "yarn build && yarn generate-api-doc",
     "watch": "vite build --watch",
     "preview": "vite preview",
-    "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "generate-api-doc": "api-extractor run"


### PR DESCRIPTION
## Why the Version Packages (#216) release run failed

Three distinct things, only one of them a repo bug:

1. **`courier-vue` build race (fixed here).** `changeset publish` publishes all packages **concurrently** (`pLimit(10)` + `Promise.all`), and every package had `"prepare": "npm run build"`, so each publish re-ran its own vite build — which empties its `dist` at the start — while sibling publishes were type-resolving against those same dists. courier-vue lost the race and died with `TS2307: Cannot find module '@trycourier/courier-ui-preferences'`. The rebuilds are pure waste: `yarn release` already runs `build-packages:ci` topologically immediately before `changeset publish`. This PR removes the `prepare` script from all 9 packages that had it; publish now just packs the existing dist. Verified locally: `npm@12 pack` in courier-vue runs zero lifecycle scripts and the tarball still contains `dist/` (built by `build-packages:ci`, which passes end-to-end).

2. **`courier-vue` + `courier-angular` ENEEDAUTH (needs an npm owner — not fixable in-repo).** Both packages sit at 1.0.0 on npm and are not registered for OIDC trusted publishing, so every publish attempt fails auth. An npm owner needs to register each on npmjs.com → package → Settings → Trusted Publisher → GitHub Actions, repository `trycourier/courier-web`, workflow `release.yml` — then re-run the failed Release run (re-running is safe; publish only attempts versions missing from the registry).

3. **`courier-js` "cannot publish over 3.5.0" (benign).** 3.5.0 was published at 23:13 by the previous run; the 23:50 run's `npm info` freshness check read a stale registry copy and re-attempted it. No action needed — `npm view @trycourier/courier-js version` confirms 3.5.0 is live.

## Registry state after #216

Published and current: courier-js 3.5.0, courier-react 9.2.5, courier-react-17 9.2.5, courier-react-components 2.2.5, courier-ui-core 2.3.0, courier-ui-inbox 2.4.10, courier-ui-preferences 1.2.1, courier-ui-toast 2.1.9. Stuck pending OIDC registration: courier-vue 1.0.2, courier-angular 1.0.2.

## Also in this PR

- New `.agents/skills/npm-release-pipeline` skill documenting the release flow end-to-end (feature PR → Version Packages PR → OIDC publish) with a triage table for failed Release runs, cross-linked from the `changesets` skill.

No changeset: build/publish-config and skill docs only, no package source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)