### PR TITLE
fix(ui-core): white checkmark on saturated mid-tone brand fills (C-19427)

### DIFF
--- a/.changeset/emerald-checkmark-contrast.md
+++ b/.changeset/emerald-checkmark-contrast.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/courier-ui-core": patch
+---
+
+Fix the checkbox checkmark contrast pick: `isDarkColor` now computes true sRGB relative luminance (as its docs always claimed) instead of YIQ. Saturated mid-tone brand colors — e.g. the preferences page's emerald `#10B981`, which YIQ scored 0.5023 ("light" by a rounding error) — now correctly get a white checkmark instead of a black one.

--- a/@trycourier/courier-ui-core/src/utils/courier-colors.ts
+++ b/@trycourier/courier-ui-core/src/utils/courier-colors.ts
@@ -1,13 +1,26 @@
-/** Returns true when the given hex color looks dark (relative luminance < 0.5). */
+/**
+ * Returns true when the given hex color looks dark (sRGB relative luminance < 0.5).
+ *
+ * Uses true (gamma-decoded) relative luminance, not the quick YIQ formula: YIQ
+ * misclassifies saturated mid-tone brand colors — e.g. emerald #10B981 scores
+ * 0.5023 on YIQ ("light" by a rounding error, giving a black checkmark on a
+ * green fill) but 0.36 in relative luminance ("dark", white checkmark), which
+ * matches how such fills are perceived and the platform convention of white
+ * glyphs on saturated accent colors.
+ */
 export function isDarkColor(color: string): boolean {
   const match = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim());
   if (!match) return true;
   let v = match[1];
   if (v.length === 3) v = v.split('').map(c => c + c).join('');
-  const r = parseInt(v.substring(0, 2), 16);
-  const g = parseInt(v.substring(2, 4), 16);
-  const b = parseInt(v.substring(4, 6), 16);
-  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 < 0.5;
+  const linear = (channel: number): number => {
+    const s = channel / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const r = linear(parseInt(v.substring(0, 2), 16));
+  const g = linear(parseInt(v.substring(2, 4), 16));
+  const b = linear(parseInt(v.substring(4, 6), 16));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b < 0.5;
 }
 
 export const CourierColors = {

--- a/@trycourier/courier-ui-preferences/src/components/__tests__/courier-channel-routing.test.ts
+++ b/@trycourier/courier-ui-preferences/src/components/__tests__/courier-channel-routing.test.ts
@@ -59,6 +59,22 @@ describe("courier-channel-routing", () => {
     expect(push.getAttribute("aria-pressed")).toBe("false");
   });
 
+  it("draws a white checkmark on a saturated mid-tone brand fill", () => {
+    // Regression: #10B981 (the hosted page's emerald) scored 0.5023 on the old
+    // YIQ luminance check — "light" by a rounding error — so the checked box
+    // got a dark checkmark on a green fill. With sRGB relative luminance the
+    // fill classifies as dark and the mark must be white.
+    mountRouting((r) => {
+      r.routingOptions = ["email"];
+      r.selectedChannels = ["email"];
+      r.primaryColor = "#10B981";
+    });
+
+    const mark = document.querySelector("courier-checkbox .courier-checkbox-mark path");
+    expect(mark).not.toBeNull();
+    expect(mark?.getAttribute("fill")).toBe("#FFFFFF");
+  });
+
   it("adds a channel on click and fires onRoutingChange", () => {
     const handler = jest.fn();
     mountRouting((r) => {


### PR DESCRIPTION
From [C-19427](https://linear.app/trycourier/issue/C-19427/frontend-overhaul-docs-feedback-thomas-jul-18) follow-up feedback: the checked channel checkbox shows a **black** checkmark on the emerald brand fill in the preferences component preview and the hosted preferences page — it should be white.

## Root cause
`isDarkColor` (courier-ui-core) documents *"relative luminance < 0.5"* but computed **YIQ** luminance. The preferences emerald `#10B981` scores **0.5023** on YIQ — classified "light" by a rounding error — so `courier-checkbox` picked the dark `#171717` mark for a green fill. The checked fill is the *resolved brand primary* (dynamic per workspace), which is why this can't be fixed with a static theme value in the consumers: the component must compute the on-color per fill.

## Fix
Compute true (gamma-decoded) sRGB relative luminance, matching the function's documented contract:

| Fill | before (YIQ) | after (relative luminance) |
|------|--------------|---------------------------|
| `#10B981` emerald | 0.5023 → black mark ❌ | 0.364 → **white** ✅ |
| `#2563EB` default blue | white | 0.153 → white ✅ |
| `#FDE047` pale yellow | dark | 0.746 → dark ✅ (stays legible) |

Blast radius: `isDarkColor`'s only consumer is `courier-checkbox`, which is only used by the preferences channel chips.

## Verification
- New regression test in `courier-channel-routing.test.ts` (mounts the routing chips with `primaryColor #10B981`, asserts the mark path fill is `#FFFFFF`). **Proven both ways**: fails against the old dist, passes with the fix.
- Full `courier-ui-preferences` suite: 50/50 green.
- `courier-ui-core` build + api-extractor pass (no API surface change).

Changeset: `@trycourier/courier-ui-core` patch (dependents auto patch-bump via `updateInternalDependencies`).

Reaches the Studio preview via the vendored dist in `frontend` and the hosted page via the embed bundle rebuild — both after this merges/releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)