### PR TITLE
feat(inbox): forward `from` date filter to inbox query (SUP-691)

### DIFF
--- a/.changeset/inbox-from-date-filter.md
+++ b/.changeset/inbox-from-date-filter.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/courier-ui-inbox": minor
+---
+
+Inbox: support a `from` date filter on feed/tab filters. `CourierInboxDatasetFilter` now accepts an optional ISO 8601 `from` string, which is forwarded to the underlying `@trycourier/courier-js` query (and applied to real-time/optimistic messages) so messages created before that date are excluded from the inbox. Previously the UI component dropped `from`, so a configured "From Date" had no effect.

--- a/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-dataset.test.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-dataset.test.ts
@@ -130,6 +130,28 @@ describe("CourierInboxDataset", () => {
       expect(dataset.toInboxDataset().messages.length).toBe(0);
     });
 
+    it("should not add message created before the dataset's `from` date", () => {
+      const dataset = new CourierInboxDataset("recent", { from: "2021-06-01T00:00:00Z" });
+
+      // UNREAD_MESSAGE is created 2021-01-01, before the `from` bound
+      const result = dataset.addMessage(UNREAD_MESSAGE);
+
+      expect(result).toBe(false);
+      expect(dataset.toInboxDataset().messages.length).toBe(0);
+      expect(dataset.totalUnreadCount).toBe(0);
+    });
+
+    it("should add message created at or after the dataset's `from` date", () => {
+      const dataset = new CourierInboxDataset("recent", { from: "2021-01-01T00:00:00Z" });
+
+      const atBoundary = { ...UNREAD_MESSAGE, messageId: "at", created: "2021-01-01T00:00:00Z" };
+      const after = { ...UNREAD_MESSAGE, messageId: "after", created: "2021-02-01T00:00:00Z" };
+
+      expect(dataset.addMessage(atBoundary)).toBe(true);
+      expect(dataset.addMessage(after)).toBe(true);
+      expect(dataset.toInboxDataset().messages.length).toBe(2);
+    });
+
     it("should insert message at default index (0) when insertIndex not specified", () => {
       const dataset = new CourierInboxDataset("test", {});
 
@@ -466,6 +488,22 @@ describe("CourierInboxDataset", () => {
 
       // Should not go negative
       expect(dataset.totalUnreadCount).toBe(0);
+    });
+  });
+
+  describe("getFilter", () => {
+    it("should forward the `from` date to the courier-js query filter", () => {
+      const dataset = new CourierInboxDataset("recent", { from: "2021-06-01T00:00:00Z" });
+
+      expect(dataset.getFilter()).toEqual(
+        expect.objectContaining({ from: "2021-06-01T00:00:00Z" })
+      );
+    });
+
+    it("should leave `from` undefined when no `from` date is set", () => {
+      const dataset = new CourierInboxDataset("inbox", {});
+
+      expect(dataset.getFilter().from).toBeUndefined();
     });
   });
 });

--- a/@trycourier/courier-ui-inbox/src/datastore/inbox-dataset.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/inbox-dataset.ts
@@ -57,7 +57,8 @@ export class CourierInboxDataset {
     this._filter = {
       tags: filter.tags ? [...(filter.tags)] : undefined,
       archived: filter.archived || false,
-      status: filter.status
+      status: filter.status,
+      from: filter.from
     };
   }
 
@@ -92,6 +93,7 @@ export class CourierInboxDataset {
       tags: this._filter.tags,
       archived: this._filter.archived,
       status: this._filter.status,
+      from: this._filter.from,
     };
   }
 
@@ -406,6 +408,14 @@ export class CourierInboxDataset {
     // Is the message read state compatible with the dataset?
     if (message.read && this._filter.status === 'unread' ||
       !message.read && this._filter.status === 'read') {
+      return false;
+    }
+
+    // Is the message recent enough for the dataset's lower time bound?
+    // Mirrors the server-side `from` filter so real-time and optimistic
+    // messages created before `from` don't leak into the dataset locally.
+    if (this._filter.from && message.created &&
+      new Date(message.created).getTime() < new Date(this._filter.from).getTime()) {
       return false;
     }
 

--- a/@trycourier/courier-ui-inbox/src/types/inbox-data-set.ts
+++ b/@trycourier/courier-ui-inbox/src/types/inbox-data-set.ts
@@ -27,6 +27,12 @@ export type CourierInboxDatasetFilter = {
 
   /* Whether to limit messages to those that are read or unread. Undefined applies no state filter. */
   status?: 'read' | 'unread';
+
+  /**
+   * Lower bound on message creation time: only messages created at or after this moment are included.
+   * Pass an ISO 8601 datetime string (e.g. `new Date().toISOString()`). Undefined applies no lower bound.
+   */
+  from?: string;
 }
 
 /**

--- a/api/courier-ui-inbox.api.md
+++ b/api/courier-ui-inbox.api.md
@@ -174,6 +174,7 @@ export type CourierInboxDatasetFilter = {
     tags?: string[];
     archived?: boolean;
     status?: 'read' | 'unread';
+    from?: string;
 };
 
 // @public


### PR DESCRIPTION
## Problem

[SUP-691](https://linear.app/trycourier/issue/SUP-691) — Axial sets a "From Date" to hide inbox messages older than a given date, but old notifications keep showing up.

The Inbox GraphQL API and `@trycourier/courier-js` both support a `from` (lower creation-time bound) filter — `courier-js` serializes `from: "..."` into `FilterParamsInput` and exposes `from` on `CourierGetInboxMessagesQueryFilter`. But `@trycourier/courier-ui-inbox` never plumbed it through: its `CourierInboxDatasetFilter` only had `tags`/`archived`/`status`, and the dataset copied/re-emitted the filter field-by-field — so `from` was silently dropped and never reached the query.

## Fix (contained to `courier-ui-inbox`)

- Add optional ISO 8601 `from` to `CourierInboxDatasetFilter` (documented to mirror the courier-js field).
- Copy it into `CourierInboxDataset._filter` and emit it from `getFilter()`, so **paginated fetches and unread counts** forward it to the GraphQL query.
- Apply `from` in `messageQualifiesForDataset()` so **real-time (socket) and optimistic** messages created before `from` don't leak into the dataset locally, keeping local state consistent with the server-side filter.

No backend or `courier-js` change needed.

## Usage

```ts
{ datasetId: 'inbox', title: 'Inbox', filter: { from: '2025-01-01T00:00:00Z' } }
```

## Note for the customer

The screenshot in the ticket shows the **integration-settings** "From Date". That drives Courier's hosted/embedded inbox — it does not flow into the self-hosted `courier-ui-inbox` component. With this change, Axial passes `from` on their feed/tab filter in code.

## Testing

- `yarn test` — 60 passed (4 new: `from` include/exclude on `addMessage`, `getFilter` forwarding).
- `yarn build` — clean.
- `yarn generate-api-doc` — API report updated (`from?: string`).
- Changeset added (`minor` — new public filter option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)