### PR TITLE
feat(toast): pause auto-dismiss countdown on hover

### DIFF
--- a/.changeset/toast-hover-pause.md
+++ b/.changeset/toast-hover-pause.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/courier-ui-toast": patch
+---
+
+Pause a toast's auto-dismiss countdown while the cursor is over it, and resume the countdown from where it left off when the cursor leaves. The visual progress bar pauses and resumes in sync.

--- a/@trycourier/courier-ui-toast/src/components/__tests__/courier-toast.test.ts
+++ b/@trycourier/courier-ui-toast/src/components/__tests__/courier-toast.test.ts
@@ -205,6 +205,49 @@ describe("courier-toast", () => {
     });
   });
 
+  describe("auto-dismiss hover pause", () => {
+    it("should pause the countdown while the cursor is over the toast", () => {
+      jest.useFakeTimers();
+
+      toast.enableAutoDismiss();
+      toast.setAutoDismissTimeoutMs(5000);
+      CourierToastDatastore.shared.addMessage(INBOX_MESSAGE);
+      const item = document.querySelector("courier-toast-item") as CourierToastItem;
+
+      // Hover the toast, then fast-forward well past the auto-dismiss timeout.
+      item.dispatchEvent(new MouseEvent("mouseenter"));
+      jest.advanceTimersByTime(10_000);
+
+      // Still present — the countdown is paused while hovered.
+      expect(document.body.contains(item)).toBe(true);
+
+      jest.useRealTimers();
+    });
+
+    it("should resume the countdown when the cursor leaves", () => {
+      jest.useFakeTimers();
+
+      toast.enableAutoDismiss();
+      toast.setAutoDismissTimeoutMs(5000);
+      CourierToastDatastore.shared.addMessage(INBOX_MESSAGE);
+      const item = document.querySelector("courier-toast-item") as CourierToastItem;
+
+      // Pause while hovered...
+      item.dispatchEvent(new MouseEvent("mouseenter"));
+      jest.advanceTimersByTime(10_000);
+      expect(document.body.contains(item)).toBe(true);
+
+      // ...then leave: the countdown resumes and dismisses after the remaining
+      // time (plus the fade-out animation).
+      item.dispatchEvent(new MouseEvent("mouseleave"));
+      jest.advanceTimersByTime(5000 + 300);
+
+      expect(document.body.contains(item)).toBe(false);
+
+      jest.useRealTimers();
+    });
+  });
+
   describe("setLightTheme", () => {
     it("should set the light theme rendered if mode=light", () => {
       const lightTheme: CourierToastTheme = {

--- a/@trycourier/courier-ui-toast/src/components/courier-toast-item.ts
+++ b/@trycourier/courier-ui-toast/src/components/courier-toast-item.ts
@@ -25,6 +25,16 @@ export class CourierToastItem extends CourierBaseElement {
   /** The timeout before the toast item is auto-dismissed, applicable if _autoDismiss is true. */
   private readonly _autoDismissTimeoutMs: number;
 
+  // Auto-dismiss countdown state. The countdown is paused while the cursor is
+  // over the toast and resumed (from where it left off) when the cursor leaves,
+  // so a user reading the toast is never rushed. The JS timer and the CSS
+  // progress bar are paused/resumed together to stay in sync.
+  private _autoDismissTimerId: ReturnType<typeof setTimeout> | null = null;
+  private _autoDismissRemainingMs: number;
+  private _autoDismissStartedAt = 0;
+  private _autoDismissPaused = false;
+  private _autoDismissBar: HTMLElement | null = null;
+
   // Callbacks
   private _onItemDismissedCallback: ((props: { message: InboxMessage }) => void) | null = null;
   private _onToastItemClickCallback: ((props: CourierToastItemClickEvent) => void) | null = null;
@@ -41,6 +51,7 @@ export class CourierToastItem extends CourierBaseElement {
     this._message = props.message;
     this._autoDismiss = props.autoDismiss;
     this._autoDismissTimeoutMs = props.autoDismissTimeoutMs;
+    this._autoDismissRemainingMs = props.autoDismissTimeoutMs;
 
     this._themeManager = props.themeManager;
     this._themeSubscription = this._themeManager.subscribe((_: CourierToastTheme) => {
@@ -101,6 +112,8 @@ export class CourierToastItem extends CourierBaseElement {
    * @param timeoutMs - the animation duration to fade out the toast item
    */
   public dismiss(timeoutMs: number = CourierToastItem.dismissAnimationTimeoutMs) {
+    // Stop the countdown so it can't fire again after we've started dismissing.
+    this.clearAutoDismissTimer();
     this.classList.add('dismissing');
 
     setTimeout(() => {
@@ -112,14 +125,70 @@ export class CourierToastItem extends CourierBaseElement {
     }, timeoutMs);
   }
 
+  /** Clears the pending auto-dismiss timer, if any. */
+  private clearAutoDismissTimer(): void {
+    if (this._autoDismissTimerId !== null) {
+      clearTimeout(this._autoDismissTimerId);
+      this._autoDismissTimerId = null;
+    }
+  }
+
+  /** (Re)start the auto-dismiss timer for whatever time is left on the countdown. */
+  private scheduleAutoDismiss(): void {
+    this.clearAutoDismissTimer();
+    this._autoDismissStartedAt = Date.now();
+    this._autoDismissTimerId = setTimeout(() => this.dismiss(), this._autoDismissRemainingMs);
+  }
+
+  /**
+   * Pause the countdown while the cursor is over the toast: cancel the timer,
+   * bank the time already elapsed, and freeze the progress bar.
+   */
+  private pauseAutoDismiss = (): void => {
+    if (!this._autoDismiss || this._autoDismissPaused) {
+      return;
+    }
+    this._autoDismissPaused = true;
+    this.clearAutoDismissTimer();
+    const elapsed = Date.now() - this._autoDismissStartedAt;
+    this._autoDismissRemainingMs = Math.max(0, this._autoDismissRemainingMs - elapsed);
+    if (this._autoDismissBar) {
+      this._autoDismissBar.style.animationPlayState = 'paused';
+    }
+  };
+
+  /** Resume the countdown from where it was paused once the cursor leaves. */
+  private resumeAutoDismiss = (): void => {
+    if (!this._autoDismiss || !this._autoDismissPaused) {
+      return;
+    }
+    this._autoDismissPaused = false;
+    if (this._autoDismissBar) {
+      this._autoDismissBar.style.animationPlayState = 'running';
+    }
+    this.scheduleAutoDismiss();
+  };
+
   /** @override */
   protected onComponentMounted(): void {
     this.render();
+
+    if (this._autoDismiss) {
+      // Pause on hover, resume when the cursor leaves. mouseenter/mouseleave
+      // (not mouseover/out) fire once for the toast as a whole, ignoring moves
+      // between its children.
+      this.addEventListener('mouseenter', this.pauseAutoDismiss);
+      this.addEventListener('mouseleave', this.resumeAutoDismiss);
+      this.scheduleAutoDismiss();
+    }
   }
 
   /** @override */
   protected onComponentUnmounted(): void {
     this._themeSubscription.unsubscribe();
+    this.clearAutoDismissTimer();
+    this.removeEventListener('mouseenter', this.pauseAutoDismiss);
+    this.removeEventListener('mouseleave', this.resumeAutoDismiss);
   }
 
   get theme(): CourierToastTheme {
@@ -165,7 +234,12 @@ export class CourierToastItem extends CourierBaseElement {
     if (this._autoDismiss) {
       const autoDismiss = document.createElement('div');
       autoDismiss.classList.add('auto-dismiss');
+      // Keep the bar frozen if we re-render (e.g. theme change) while paused.
+      if (this._autoDismissPaused) {
+        autoDismiss.style.animationPlayState = 'paused';
+      }
       overflowHiddenContainer.append(autoDismiss);
+      this._autoDismissBar = autoDismiss;
     }
 
     // Content

--- a/@trycourier/courier-ui-toast/src/components/courier-toast.ts
+++ b/@trycourier/courier-ui-toast/src/components/courier-toast.ts
@@ -357,9 +357,9 @@ export class CourierToast extends CourierBaseElement {
       item.onToastItemActionClick(this._onItemActionClick);
     }
 
-    if (this._autoDismiss) {
-      setTimeout(item.dismiss.bind(item), this._autoDismissTimeoutMs);
-    }
+    // The auto-dismiss countdown (and its hover-to-pause behavior) is owned by
+    // the CourierToastItem itself, started when it mounts — see
+    // CourierToastItem.onComponentMounted.
 
     return item;
   }


### PR DESCRIPTION
## What

Hovering the cursor over a toast now **pauses** its auto-dismiss countdown; when the cursor **leaves**, the countdown **resumes from where it left off**. The visual progress bar pauses/resumes in sync with the timer.

## How

- Moved the auto-dismiss countdown from the `CourierToast` container into `CourierToastItem` (started on mount). The item owns both the hover surface and the `.auto-dismiss` progress bar, so it can pause/resume itself.
- On `mouseenter`: cancel the timer, bank the elapsed time, and freeze the bar (`animation-play-state: paused`).
- On `mouseleave`: resume the bar and re-schedule the timer for the remaining time.
- Used `mouseenter`/`mouseleave` (not `mouseover`/`out`) so moving between the toast's children doesn't restart the countdown.
- Timer is cleared on dismiss and on unmount.

Applies to the default toast item and custom **content** (`setToastItemContent`) — both render through `CourierToastItem`. A fully-custom item (`setToastItem`) still auto-dismisses via the container timer (unchanged), without hover-pause.

## Testing
- `yarn build` + `yarn test` in `@trycourier/courier-ui-toast` — **52 passing** (2 new: pauses while hovered; resumes on leave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)