### PR TITLE
fix(toast): pause the whole stack on hover, not just the item under the cursor

### DIFF
--- a/@trycourier/courier-ui-toast/src/components/__tests__/courier-toast.test.ts
+++ b/@trycourier/courier-ui-toast/src/components/__tests__/courier-toast.test.ts
@@ -206,6 +206,9 @@ describe("courier-toast", () => {
   });
 
   describe("auto-dismiss hover pause", () => {
+    const hover = () => toast.dispatchEvent(new MouseEvent("mouseenter"));
+    const unhover = () => toast.dispatchEvent(new MouseEvent("mouseleave"));
+
     it("should pause the countdown while the cursor is over the toast", () => {
       jest.useFakeTimers();
 
@@ -215,7 +218,7 @@ describe("courier-toast", () => {
       const item = document.querySelector("courier-toast-item") as CourierToastItem;
 
       // Hover the toast, then fast-forward well past the auto-dismiss timeout.
-      item.dispatchEvent(new MouseEvent("mouseenter"));
+      hover();
       jest.advanceTimersByTime(10_000);
 
       // Still present — the countdown is paused while hovered.
@@ -233,15 +236,126 @@ describe("courier-toast", () => {
       const item = document.querySelector("courier-toast-item") as CourierToastItem;
 
       // Pause while hovered...
-      item.dispatchEvent(new MouseEvent("mouseenter"));
+      hover();
       jest.advanceTimersByTime(10_000);
       expect(document.body.contains(item)).toBe(true);
 
       // ...then leave: the countdown resumes and dismisses after the remaining
       // time (plus the fade-out animation).
-      item.dispatchEvent(new MouseEvent("mouseleave"));
+      unhover();
       jest.advanceTimersByTime(5000 + 300);
 
+      expect(document.body.contains(item)).toBe(false);
+
+      jest.useRealTimers();
+    });
+
+    it("should resume the countdown from where it left off, not restart it", () => {
+      jest.useFakeTimers();
+
+      toast.enableAutoDismiss();
+      toast.setAutoDismissTimeoutMs(5000);
+      CourierToastDatastore.shared.addMessage(INBOX_MESSAGE);
+      const item = document.querySelector("courier-toast-item") as CourierToastItem;
+
+      // 4s of the 5s countdown elapses, then the cursor arrives and parks for a while.
+      jest.advanceTimersByTime(4000);
+      hover();
+      jest.advanceTimersByTime(60_000);
+      expect(document.body.contains(item)).toBe(true);
+
+      // On leaving, only the banked 1s is left — not another full 5s.
+      unhover();
+      jest.advanceTimersByTime(1000 + 300);
+      expect(document.body.contains(item)).toBe(false);
+
+      jest.useRealTimers();
+    });
+
+    it("should pause every item in the stack, not just the top one", () => {
+      jest.useFakeTimers();
+
+      toast.enableAutoDismiss();
+      toast.setAutoDismissTimeoutMs(5000);
+      CourierToastDatastore.shared.addMessage({ ...INBOX_MESSAGE, messageId: "1" });
+      CourierToastDatastore.shared.addMessage({ ...INBOX_MESSAGE, messageId: "2" });
+      CourierToastDatastore.shared.addMessage({ ...INBOX_MESSAGE, messageId: "3" });
+
+      // The whole stack is one hover surface: reading the top toast shouldn't
+      // silently burn down the countdowns of the ones queued behind it.
+      hover();
+      jest.advanceTimersByTime(30_000);
+
+      expect(document.querySelectorAll("courier-toast-item").length).toBe(3);
+
+      jest.useRealTimers();
+    });
+
+    it("should keep a hovered toast paused when a new toast arrives on top of it", () => {
+      jest.useFakeTimers();
+
+      toast.enableAutoDismiss();
+      toast.setAutoDismissTimeoutMs(5000);
+      CourierToastDatastore.shared.addMessage({ ...INBOX_MESSAGE, messageId: "1" });
+      const firstItem = document.querySelector("courier-toast-item") as CourierToastItem;
+
+      hover();
+      jest.advanceTimersByTime(1000);
+
+      // The new toast lands under the cursor, which pushes the first item down the
+      // stack. The cursor never left the toast, so neither countdown may resume.
+      CourierToastDatastore.shared.addMessage({ ...INBOX_MESSAGE, messageId: "2" });
+      jest.advanceTimersByTime(30_000);
+
+      expect(document.body.contains(firstItem)).toBe(true);
+      expect(document.querySelectorAll("courier-toast-item").length).toBe(2);
+
+      jest.useRealTimers();
+    });
+
+    it("should pause a toast that arrives while the cursor is already over the stack", () => {
+      jest.useFakeTimers();
+
+      toast.enableAutoDismiss();
+      toast.setAutoDismissTimeoutMs(5000);
+
+      // The cursor is parked where the toast is about to appear.
+      hover();
+      CourierToastDatastore.shared.addMessage(INBOX_MESSAGE);
+      const item = document.querySelector("courier-toast-item") as CourierToastItem;
+
+      jest.advanceTimersByTime(30_000);
+      expect(document.body.contains(item)).toBe(true);
+
+      // The full countdown is still owed once the cursor leaves.
+      unhover();
+      jest.advanceTimersByTime(4999);
+      expect(document.body.contains(item)).toBe(true);
+      jest.advanceTimersByTime(1 + 300);
+      expect(document.body.contains(item)).toBe(false);
+
+      jest.useRealTimers();
+    });
+
+    it("should pause the countdown of a custom toast item", () => {
+      jest.useFakeTimers();
+
+      toast.setToastItem(() => {
+        const el = document.createElement("div");
+        el.id = "custom-item";
+        return el;
+      });
+      toast.enableAutoDismiss();
+      toast.setAutoDismissTimeoutMs(5000);
+      CourierToastDatastore.shared.addMessage(INBOX_MESSAGE);
+      const item = document.getElementById("custom-item") as HTMLElement;
+
+      hover();
+      jest.advanceTimersByTime(30_000);
+      expect(document.body.contains(item)).toBe(true);
+
+      unhover();
+      jest.advanceTimersByTime(5000);
       expect(document.body.contains(item)).toBe(false);
 
       jest.useRealTimers();

--- a/@trycourier/courier-ui-toast/src/components/courier-toast-item.ts
+++ b/@trycourier/courier-ui-toast/src/components/courier-toast-item.ts
@@ -3,6 +3,7 @@ import { CourierToastThemeManager, CourierToastThemeSubscription } from "../type
 import { CourierToastTheme } from "../types/courier-toast-theme";
 import { InboxAction, InboxMessage } from "@trycourier/courier-js";
 import { CourierToastItemActionClickEvent, CourierToastItemClickEvent, CourierToastItemFactoryProps } from "../types/toast";
+import { PausableTimeout } from "../utils/pausable-timeout";
 
 /**
  * Default implementation of a Toast item.
@@ -27,12 +28,12 @@ export class CourierToastItem extends CourierBaseElement {
 
   // Auto-dismiss countdown state. The countdown is paused while the cursor is
   // over the toast and resumed (from where it left off) when the cursor leaves,
-  // so a user reading the toast is never rushed. The JS timer and the CSS
-  // progress bar are paused/resumed together to stay in sync.
-  private _autoDismissTimerId: ReturnType<typeof setTimeout> | null = null;
-  private _autoDismissRemainingMs: number;
-  private _autoDismissStartedAt = 0;
-  private _autoDismissPaused = false;
+  // so a user reading the toast is never rushed. Hover is tracked by the
+  // containing CourierToast, which pauses/resumes every item in the stack —
+  // see CourierToast.setAutoDismissPaused.
+  private _autoDismissTimeout: PausableTimeout | null = null;
+
+  /** The progress bar element, paused/resumed alongside the countdown to stay in sync. */
   private _autoDismissBar: HTMLElement | null = null;
 
   // Callbacks
@@ -51,7 +52,6 @@ export class CourierToastItem extends CourierBaseElement {
     this._message = props.message;
     this._autoDismiss = props.autoDismiss;
     this._autoDismissTimeoutMs = props.autoDismissTimeoutMs;
-    this._autoDismissRemainingMs = props.autoDismissTimeoutMs;
 
     this._themeManager = props.themeManager;
     this._themeSubscription = this._themeManager.subscribe((_: CourierToastTheme) => {
@@ -113,7 +113,7 @@ export class CourierToastItem extends CourierBaseElement {
    */
   public dismiss(timeoutMs: number = CourierToastItem.dismissAnimationTimeoutMs) {
     // Stop the countdown so it can't fire again after we've started dismissing.
-    this.clearAutoDismissTimer();
+    this._autoDismissTimeout?.cancel();
     this.classList.add('dismissing');
 
     setTimeout(() => {
@@ -125,70 +125,52 @@ export class CourierToastItem extends CourierBaseElement {
     }, timeoutMs);
   }
 
-  /** Clears the pending auto-dismiss timer, if any. */
-  private clearAutoDismissTimer(): void {
-    if (this._autoDismissTimerId !== null) {
-      clearTimeout(this._autoDismissTimerId);
-      this._autoDismissTimerId = null;
-    }
-  }
-
-  /** (Re)start the auto-dismiss timer for whatever time is left on the countdown. */
-  private scheduleAutoDismiss(): void {
-    this.clearAutoDismissTimer();
-    this._autoDismissStartedAt = Date.now();
-    this._autoDismissTimerId = setTimeout(() => this.dismiss(), this._autoDismissRemainingMs);
+  /**
+   * Pause the auto-dismiss countdown, banking the time already elapsed and
+   * freezing the progress bar so the two stay in sync.
+   *
+   * Called by the containing {@link CourierToast} while the cursor is over the
+   * toast stack. No-op if this item doesn't auto-dismiss.
+   */
+  public pauseAutoDismiss(): void {
+    this._autoDismissTimeout?.pause();
+    this.syncAutoDismissBarPlayState();
   }
 
   /**
-   * Pause the countdown while the cursor is over the toast: cancel the timer,
-   * bank the time already elapsed, and freeze the progress bar.
+   * Resume a paused auto-dismiss countdown from where it left off.
+   *
+   * Called by the containing {@link CourierToast} once the cursor leaves the
+   * toast stack. No-op if this item doesn't auto-dismiss.
    */
-  private pauseAutoDismiss = (): void => {
-    if (!this._autoDismiss || this._autoDismissPaused) {
-      return;
-    }
-    this._autoDismissPaused = true;
-    this.clearAutoDismissTimer();
-    const elapsed = Date.now() - this._autoDismissStartedAt;
-    this._autoDismissRemainingMs = Math.max(0, this._autoDismissRemainingMs - elapsed);
-    if (this._autoDismissBar) {
-      this._autoDismissBar.style.animationPlayState = 'paused';
-    }
-  };
+  public resumeAutoDismiss(): void {
+    this._autoDismissTimeout?.resume();
+    this.syncAutoDismissBarPlayState();
+  }
 
-  /** Resume the countdown from where it was paused once the cursor leaves. */
-  private resumeAutoDismiss = (): void => {
-    if (!this._autoDismiss || !this._autoDismissPaused) {
+  /** Freeze/unfreeze the progress bar to match the countdown. */
+  private syncAutoDismissBarPlayState(): void {
+    if (!this._autoDismissBar) {
       return;
     }
-    this._autoDismissPaused = false;
-    if (this._autoDismissBar) {
-      this._autoDismissBar.style.animationPlayState = 'running';
-    }
-    this.scheduleAutoDismiss();
-  };
+
+    this._autoDismissBar.style.animationPlayState = this._autoDismissTimeout?.isPaused ? 'paused' : 'running';
+  }
 
   /** @override */
   protected onComponentMounted(): void {
     this.render();
 
     if (this._autoDismiss) {
-      // Pause on hover, resume when the cursor leaves. mouseenter/mouseleave
-      // (not mouseover/out) fire once for the toast as a whole, ignoring moves
-      // between its children.
-      this.addEventListener('mouseenter', this.pauseAutoDismiss);
-      this.addEventListener('mouseleave', this.resumeAutoDismiss);
-      this.scheduleAutoDismiss();
+      this._autoDismissTimeout = new PausableTimeout(() => this.dismiss(), this._autoDismissTimeoutMs);
+      this._autoDismissTimeout.start();
     }
   }
 
   /** @override */
   protected onComponentUnmounted(): void {
     this._themeSubscription.unsubscribe();
-    this.clearAutoDismissTimer();
-    this.removeEventListener('mouseenter', this.pauseAutoDismiss);
-    this.removeEventListener('mouseleave', this.resumeAutoDismiss);
+    this._autoDismissTimeout?.cancel();
   }
 
   get theme(): CourierToastTheme {
@@ -235,7 +217,7 @@ export class CourierToastItem extends CourierBaseElement {
       const autoDismiss = document.createElement('div');
       autoDismiss.classList.add('auto-dismiss');
       // Keep the bar frozen if we re-render (e.g. theme change) while paused.
-      if (this._autoDismissPaused) {
+      if (this._autoDismissTimeout?.isPaused) {
         autoDismiss.style.animationPlayState = 'paused';
       }
       overflowHiddenContainer.append(autoDismiss);

--- a/@trycourier/courier-ui-toast/src/components/courier-toast.ts
+++ b/@trycourier/courier-ui-toast/src/components/courier-toast.ts
@@ -7,6 +7,7 @@ import { CourierToastItemActionClickEvent, CourierToastItemClickEvent, CourierTo
 import { CourierToastDismissButtonOption } from "../types/toast";
 import { CourierToastDatastoreListener } from "../datastore/toast-datastore-listener";
 import { CourierToastDatastore } from "../datastore/toast-datastore";
+import { PausableTimeout } from "../utils/pausable-timeout";
 
 /** Default set of CSS properties used to layout CourierToast. */
 type CourierToastLayoutProps = {
@@ -48,6 +49,22 @@ export class CourierToast extends CourierBaseElement {
   private _toastStyle?: HTMLStyleElement;
   private _authListener?: AuthenticationListener;
   private _datastoreListener: CourierToastDatastoreListener;
+
+  /**
+   * Whether the cursor is currently over the toast stack.
+   *
+   * Hover is tracked here — on the container — rather than per item, because
+   * the stacked items are one hover surface: moving between them (or a new
+   * toast arriving under the cursor) must not resume anyone's countdown.
+   */
+  private _isHovered = false;
+
+  /**
+   * Auto-dismiss countdowns for custom toast items set via
+   * {@link CourierToast.setToastItem}. {@link CourierToastItem}s own their own
+   * countdown, so they're not tracked here.
+   */
+  private _customItemAutoDismissTimeouts = new WeakMap<HTMLElement, PausableTimeout>();
 
   // Consumer-provided options
   private _autoDismiss: boolean = false;
@@ -221,6 +238,7 @@ export class CourierToast extends CourierBaseElement {
       if (node instanceof CourierToastItem) {
         node.dismiss();
       } else {
+        this._customItemAutoDismissTimeouts.get(node as HTMLElement)?.cancel();
         node.remove();
       }
     });
@@ -232,6 +250,13 @@ export class CourierToast extends CourierBaseElement {
   protected onComponentMounted(): void {
     this._toastStyle = injectGlobalStyle(CourierToast.id, this.getStyles(this.theme));
 
+    // Pause every countdown in the stack while the cursor is over the toast, so
+    // a user reading it is never rushed. mouseenter/mouseleave (not
+    // mouseover/mouseout) fire once for the container's whole subtree, so moving
+    // between toast items and their children doesn't resume the countdown.
+    this.addEventListener('mouseenter', this.onMouseEnter);
+    this.addEventListener('mouseleave', this.onMouseLeave);
+
     CourierToastDatastore.shared.addDatastoreListener(this._datastoreListener);
     Courier.shared.addAuthenticationListener(this.authChangedCallback.bind(this));
     CourierToastDatastore.shared.listenForMessages();
@@ -241,11 +266,40 @@ export class CourierToast extends CourierBaseElement {
    * @override
    */
   protected onComponentUnmounted(): void {
+    this.removeEventListener('mouseenter', this.onMouseEnter);
+    this.removeEventListener('mouseleave', this.onMouseLeave);
+
     this._datastoreListener.remove();
     this._authListener?.remove();
     this._toastStyle?.remove();
     this._themeManager.cleanup();
     this._themeSubscription.unsubscribe();
+  }
+
+  private onMouseEnter = (): void => {
+    this._isHovered = true;
+    this.setAutoDismissPaused(true);
+  };
+
+  private onMouseLeave = (): void => {
+    this._isHovered = false;
+    this.setAutoDismissPaused(false);
+  };
+
+  /** Pause or resume the auto-dismiss countdown of every item in the stack. */
+  private setAutoDismissPaused(paused: boolean): void {
+    Array.from(this.children).forEach(child => this.setItemAutoDismissPaused(child as HTMLElement, paused));
+  }
+
+  /** Pause or resume a single item's auto-dismiss countdown. */
+  private setItemAutoDismissPaused(item: HTMLElement, paused: boolean): void {
+    if (item instanceof CourierToastItem) {
+      paused ? item.pauseAutoDismiss() : item.resumeAutoDismiss();
+      return;
+    }
+
+    const customItemTimeout = this._customItemAutoDismissTimeouts.get(item);
+    paused ? customItemTimeout?.pause() : customItemTimeout?.resume();
   }
 
   /**
@@ -309,6 +363,7 @@ export class CourierToast extends CourierBaseElement {
 
   private removeAllItems(): void {
     while (this.firstChild) {
+      this._customItemAutoDismissTimeouts.get(this.firstChild as HTMLElement)?.cancel();
       this.removeChild(this.firstChild);
     }
   }
@@ -321,6 +376,12 @@ export class CourierToast extends CourierBaseElement {
     toastItem.dataset.courierMessageId = message.messageId;
     this.appendChild(toastItem);
     this.resizeContainerToHeight(this.topStackItemHeight);
+
+    // A toast that arrives while the cursor is already over the stack starts out
+    // paused — it just landed under the cursor, so it hasn't been read yet.
+    if (this._isHovered) {
+      this.setItemAutoDismissPaused(toastItem, /* paused= */ true);
+    }
 
     return toastItem;
   }
@@ -376,9 +437,11 @@ export class CourierToast extends CourierBaseElement {
     });
 
     if (this._autoDismiss) {
-      setTimeout(() => {
-        this.removeChild(customItem);
-      }, this._autoDismissTimeoutMs);
+      // Custom items have no countdown of their own, so the container owns it —
+      // including pausing it while the cursor is over the toast.
+      const autoDismissTimeout = new PausableTimeout(() => customItem.remove(), this._autoDismissTimeoutMs);
+      this._customItemAutoDismissTimeouts.set(customItem, autoDismissTimeout);
+      autoDismissTimeout.start();
     }
 
     customItem.addEventListener('click', () => {

--- a/@trycourier/courier-ui-toast/src/utils/pausable-timeout.ts
+++ b/@trycourier/courier-ui-toast/src/utils/pausable-timeout.ts
@@ -1,0 +1,85 @@
+/**
+ * A `setTimeout` that can be paused and resumed.
+ *
+ * Pausing banks the time that has already elapsed, so resuming fires the
+ * callback after the *remaining* time rather than restarting the full delay.
+ *
+ * Used for the toast auto-dismiss countdown, which pauses while the cursor is
+ * over the toast.
+ */
+export class PausableTimeout {
+  private readonly _callback: () => void;
+
+  /** Time left on the countdown, updated each time it's paused. */
+  private _remainingMs: number;
+
+  private _timerId: ReturnType<typeof setTimeout> | null = null;
+
+  /** When the currently-running countdown was (re)started. */
+  private _startedAt = 0;
+
+  private _isPaused = false;
+
+  /** Set once the callback has fired (or the countdown was cancelled). */
+  private _isDone = false;
+
+  constructor(callback: () => void, delayMs: number) {
+    this._callback = callback;
+    this._remainingMs = delayMs;
+  }
+
+  /** Whether the countdown is currently paused. */
+  public get isPaused(): boolean {
+    return this._isPaused;
+  }
+
+  /** Start the countdown for whatever time is left on it. */
+  public start(): void {
+    if (this._isDone) {
+      return;
+    }
+
+    this.clear();
+    this._isPaused = false;
+    this._startedAt = Date.now();
+    this._timerId = setTimeout(() => {
+      this._timerId = null;
+      this._isDone = true;
+      this._callback();
+    }, this._remainingMs);
+  }
+
+  /** Pause the countdown, banking the time that has already elapsed. */
+  public pause(): void {
+    if (this._isDone || this._isPaused || this._timerId === null) {
+      return;
+    }
+
+    this._remainingMs = Math.max(0, this._remainingMs - (Date.now() - this._startedAt));
+    this._isPaused = true;
+    this.clear();
+  }
+
+  /** Resume a paused countdown from where it left off. */
+  public resume(): void {
+    if (this._isDone || !this._isPaused) {
+      return;
+    }
+
+    this.start();
+  }
+
+  /** Cancel the countdown for good; it can't be started again. */
+  public cancel(): void {
+    this._isPaused = false;
+    this._isDone = true;
+    this.clear();
+  }
+
+  private clear(): void {
+    if (this._timerId !== null) {
+      clearTimeout(this._timerId);
+      this._timerId = null;
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Agent instructions (courier-web)
+
+**This repository is public.** Everything committed here — code, comments, docs,
+skills, commit messages — is world-readable. Keep internal-only material (other
+Courier repos and their layout, deploy/hosting setup, dashboards, ticket numbers,
+customer names, credentials) out of it. Notes about how another repo consumes these
+packages belong in that repo, not here.
+
+## Layout
+
+| Path | What |
+| --- | --- |
+| `@trycourier/*` | The published packages (`courier-js`, `courier-ui-core`, `courier-ui-inbox`, `courier-ui-toast`, `courier-ui-preferences`, `courier-react`, `courier-react-17`, `courier-react-components`, `courier-vue`, `courier-angular`) |
+| `examples/*` | Runnable example apps (`web-js`, `vue`, `angular`, `react-latest`, `react-17`, `next-latest`, `next-12`) |
+| `designer/` | Internal theming/designer app |
+| `api/*.api.md` | Committed API Extractor reports — CI fails if these drift |
+| `.agents/skills/` | Task-specific instructions (`.claude/skills` is a symlink to it) |
+
+Packages depend on each other through their **built `dist/`**, not their source, so
+a source edit isn't visible to tests or examples until you rebuild.
+
+## Commands
+
+```bash
+yarn install
+yarn build-packages          # build all packages (needed before tests/examples resolve)
+yarn sync                    # clean reinstall + rebuild, when things look stale
+yarn test:all                # every package's suite
+yarn workspace @trycourier/<pkg> run test
+yarn workspace <example> run dev
+yarn generate-api-docs       # refresh api/*.api.md after an intentional API change
+yarn build-packages:ci       # what CI runs: build + API report check
+```
+
+## Skills
+
+Read the matching skill in `.agents/skills/` before starting; each one documents the
+places a change of that kind has to touch.
+
+| Skill | Use for |
+| --- | --- |
+| `sync-packages` | `Cannot find module '@trycourier/...'`, stale `dist/` |
+| `run-tests` | Running a package suite or reproducing a CI test failure |
+| `api-reports` | CI failing on an API diff, or refreshing a report after an API change |
+| `changesets` | Version bumps for a release |
+| `npm-release-pipeline` | Release run failures, missing changelogs, publish problems |
+| `run-example-app` | Running an example to check a change in a browser |
+| `add-example-app` | Registering a brand-new example app |
+| `sync-examples` | Keeping the react/vue/angular showcases at feature parity |
+| `update-component-theme` | Changing or adding a themable style |
+
+## Conventions
+
+- Match the surrounding code's style, naming, and comment density. Comments explain
+  *why*, not *what*.
+- A behavior change to a component needs both: a test where the behavior can be
+  expressed, and a check in a real browser via an example app — jsdom has no
+  hit-testing, no `:hover`, no layout, and no CSS animations, so hover, stacking,
+  and timer bugs are invisible to it. If no example exercises the feature (several
+  options default to off), add one as part of the change.
+- Public API changes must ship with the regenerated `api/*.api.md` in the same PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/api/courier-ui-toast.api.md
+++ b/api/courier-ui-toast.api.md
@@ -141,6 +141,8 @@ export class CourierToastItem extends CourierBaseElement {
     }) => void): void;
     onToastItemActionClick(handler: (props: CourierToastItemActionClickEvent) => void): void;
     onToastItemClick(handler: (props: CourierToastItemClickEvent) => void): void;
+    pauseAutoDismiss(): void;
+    resumeAutoDismiss(): void;
     setToastItemContent(factory?: (props: CourierToastItemFactoryProps) => HTMLElement): void;
     // (undocumented)
     get theme(): CourierToastTheme;

--- a/examples/angular/src/app/pages/examples.component.ts
+++ b/examples/angular/src/app/pages/examples.component.ts
@@ -107,6 +107,7 @@ export class ExamplesComponent {
     { to: '/examples/toast-basic', title: 'Toast — Basic', description: 'Toast notifications using the default Courier Toast theme.' },
     { to: '/examples/toast-themed', title: 'Toast — Themed', description: 'Toast notifications using a Poppins-based custom theme.' },
     { to: '/examples/toast-custom', title: 'Toast — Custom', description: 'Toast notifications rendered with a fully custom Angular template.' },
+    { to: '/examples/toast-auto-dismiss', title: 'Toast — Auto-dismiss', description: 'Timed toasts with a countdown bar that pauses while hovered.' },
   ];
 
   readonly preferencesExamples: ExampleCard[] = [

--- a/examples/angular/src/app/pages/toast-auto-dismiss.component.ts
+++ b/examples/angular/src/app/pages/toast-auto-dismiss.component.ts
@@ -1,0 +1,62 @@
+import { Component, OnInit } from '@angular/core';
+import { CourierToastComponent, CourierService } from '@trycourier/courier-angular';
+
+const AUTO_DISMISS_TIMEOUT_MS = 6000;
+
+@Component({
+  selector: 'app-toast-auto-dismiss',
+  standalone: true,
+  imports: [CourierToastComponent],
+  template: `
+    <div
+      style="margin: 0; min-height: 100vh; padding: 40px; box-sizing: border-box; background: white;
+             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;"
+    >
+      <h1 style="margin: 0 0 6px; font-size: 22px;">Toast — Auto-dismiss timer</h1>
+      <p style="margin: 0 0 20px; font-size: 13px; color: #555555; max-width: 560px;">
+        Each toast dismisses itself after {{ autoDismissTimeoutMs / 1000 }} seconds, counted
+        down by the timer bar across the top of the toast. Hover the toast to freeze the
+        countdown — every toast in the stack pauses, and they all resume from where they left
+        off once the cursor leaves.
+      </p>
+
+      <div style="display: flex; gap: 8px;">
+        <button type="button" (click)="showToast()">Show timed toast</button>
+        <button type="button" (click)="showToastStack()">Show 3 timed toasts</button>
+      </div>
+
+      <courier-toast [autoDismiss]="true" [autoDismissTimeoutMs]="autoDismissTimeoutMs"></courier-toast>
+    </div>
+  `,
+})
+export class ToastAutoDismissComponent implements OnInit {
+  readonly autoDismissTimeoutMs = AUTO_DISMISS_TIMEOUT_MS;
+
+  /** Toasts are matched to messages by id, so each one needs a distinct id. */
+  private count = 0;
+
+  constructor(private courier: CourierService) {}
+
+  ngOnInit(): void {
+    this.courier.signIn({
+      userId: import.meta.env.VITE_USER_ID,
+      jwt: import.meta.env.VITE_JWT,
+    });
+  }
+
+  showToast(): void {
+    this.count += 1;
+    this.courier.addToastMessage({
+      messageId: `auto-dismiss-${this.count}`,
+      title: `📸 New photos from Fred L. (${this.count})`,
+      body: 'Fred shared 4 photos.',
+      actions: [{ content: 'See more' }, { content: 'Mark read' }],
+    });
+  }
+
+  showToastStack(): void {
+    this.showToast();
+    this.showToast();
+    this.showToast();
+  }
+}

--- a/examples/angular/src/app/routes.ts
+++ b/examples/angular/src/app/routes.ts
@@ -22,6 +22,7 @@ import { MarkdownListItemComponent } from './pages/markdown-list-item.component'
 import { ToastBasicComponent } from './pages/toast-basic.component';
 import { ToastThemedComponent } from './pages/toast-themed.component';
 import { ToastCustomComponent } from './pages/toast-custom.component';
+import { ToastAutoDismissComponent } from './pages/toast-auto-dismiss.component';
 import { HooksComponent } from './pages/hooks.component';
 import { PreferencesDefaultComponent } from './pages/preferences-default.component';
 import { PreferencesStyledComponent } from './pages/preferences-styled.component';
@@ -70,6 +71,7 @@ export const routes: Routes = [
   { path: 'examples/toast-basic', component: ToastBasicComponent },
   { path: 'examples/toast-themed', component: ToastThemedComponent },
   { path: 'examples/toast-custom', component: ToastCustomComponent },
+  { path: 'examples/toast-auto-dismiss', component: ToastAutoDismissComponent },
   { path: 'examples/toast', component: ToastCustomComponent },
   { path: 'examples/hooks', component: HooksComponent },
 

--- a/examples/next-latest/src/app/examples/page.tsx
+++ b/examples/next-latest/src/app/examples/page.tsx
@@ -131,6 +131,9 @@ export default function Examples() {
           <ExampleCard to="/examples/toast-custom" title="Toast — Custom">
             Toast notifications rendered with a fully custom React component.
           </ExampleCard>
+          <ExampleCard to="/examples/toast-auto-dismiss" title="Toast — Auto-dismiss">
+            Timed toasts with a countdown bar that pauses while hovered.
+          </ExampleCard>
         </div>
 
         {/* Preferences examples */}

--- a/examples/next-latest/src/app/examples/toast-auto-dismiss/page.tsx
+++ b/examples/next-latest/src/app/examples/toast-auto-dismiss/page.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useRef } from 'react';
+import { CourierToast, useCourier } from '@trycourier/courier-react';
+
+const AUTO_DISMISS_TIMEOUT_MS = 6000;
+
+export default function ToastAutoDismiss() {
+  const courier = useCourier();
+
+  // Toasts are matched to messages by id, so each one needs a distinct id.
+  const count = useRef(0);
+
+  useEffect(() => {
+    courier.shared.signIn({
+      userId: process.env.NEXT_PUBLIC_USER_ID!,
+      jwt: process.env.NEXT_PUBLIC_JWT!,
+    });
+  }, []);
+
+  const showToast = () => {
+    count.current += 1;
+    courier.toast.addMessage({
+      messageId: `auto-dismiss-${count.current}`,
+      title: `📸 New photos from Fred L. (${count.current})`,
+      body: 'Fred shared 4 photos.',
+      actions: [
+        { content: 'See more' },
+        { content: 'Mark read' },
+      ],
+    });
+  };
+
+  const showToastStack = () => {
+    showToast();
+    showToast();
+    showToast();
+  };
+
+  return (
+    <div
+      style={{
+        margin: 0,
+        minHeight: '100vh',
+        padding: 40,
+        boxSizing: 'border-box',
+        background: 'white',
+        fontFamily:
+          "-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+      }}
+    >
+      <h1 style={{ margin: '0 0 6px', fontSize: 22 }}>
+        Toast — Auto-dismiss timer
+      </h1>
+      <p style={{ margin: '0 0 20px', fontSize: 13, color: '#555555', maxWidth: 560 }}>
+        Each toast dismisses itself after {AUTO_DISMISS_TIMEOUT_MS / 1000} seconds, counted
+        down by the timer bar across the top of the toast. Hover the toast to freeze the
+        countdown — every toast in the stack pauses, and they all resume from where they
+        left off once the cursor leaves.
+      </p>
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button type="button" onClick={showToast}>
+          Show timed toast
+        </button>
+        <button type="button" onClick={showToastStack}>
+          Show 3 timed toasts
+        </button>
+      </div>
+
+      <CourierToast
+        autoDismiss
+        autoDismissTimeoutMs={AUTO_DISMISS_TIMEOUT_MS}
+      />
+    </div>
+  );
+}

--- a/examples/react-17/src/App.tsx
+++ b/examples/react-17/src/App.tsx
@@ -17,6 +17,7 @@ import MarkdownListItemInbox from './MarkdownListItem';
 import ToastBasic from './ToastBasic';
 import ToastThemed from './ToastThemed';
 import ToastCustom from './ToastCustom';
+import ToastAutoDismiss from './ToastAutoDismiss';
 import Hooks from './Hooks';
 import InboxCustomFeed from './InboxCustomFeed';
 import InboxCustomTabs from './InboxCustomTabs';
@@ -76,6 +77,7 @@ function App() {
         <Route path="/examples/toast-basic" element={<ToastBasic />} />
         <Route path="/examples/toast-themed" element={<ToastThemed />} />
         <Route path="/examples/toast-custom" element={<ToastCustom />} />
+        <Route path="/examples/toast-auto-dismiss" element={<ToastAutoDismiss />} />
         <Route path="/examples/toast" element={<ToastCustom />} />
         <Route path="/examples/hooks" element={<Hooks />} />
       </Routes>

--- a/examples/react-17/src/Examples.tsx
+++ b/examples/react-17/src/Examples.tsx
@@ -129,6 +129,9 @@ export default function Examples() {
           <ExampleCard to="/examples/toast-custom" title="Toast — Custom">
             Toast notifications rendered with a fully custom React component.
           </ExampleCard>
+          <ExampleCard to="/examples/toast-auto-dismiss" title="Toast — Auto-dismiss">
+            Timed toasts with a countdown bar that pauses while hovered.
+          </ExampleCard>
         </div>
 
         {/* Preferences examples */}

--- a/examples/react-17/src/ToastAutoDismiss.tsx
+++ b/examples/react-17/src/ToastAutoDismiss.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { CourierToast, useCourier } from '@trycourier/courier-react-17';
+
+const AUTO_DISMISS_TIMEOUT_MS = 6000;
+
+export default function ToastAutoDismiss() {
+  const courier = useCourier();
+
+  // Toasts are matched to messages by id, so each one needs a distinct id.
+  const count = useRef(0);
+
+  useEffect(() => {
+    courier.shared.signIn({
+      userId: import.meta.env.VITE_USER_ID,
+      jwt: import.meta.env.VITE_JWT,
+    });
+  }, []);
+
+  const showToast = () => {
+    count.current += 1;
+    courier.toast.addMessage({
+      messageId: `auto-dismiss-${count.current}`,
+      title: `📸 New photos from Fred L. (${count.current})`,
+      body: 'Fred shared 4 photos.',
+      actions: [
+        { content: 'See more' },
+        { content: 'Mark read' },
+      ],
+    });
+  };
+
+  const showToastStack = () => {
+    showToast();
+    showToast();
+    showToast();
+  };
+
+  return (
+    <div
+      style={{
+        margin: 0,
+        minHeight: '100vh',
+        padding: 40,
+        boxSizing: 'border-box',
+        background: 'white',
+        fontFamily:
+          "-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+      }}
+    >
+      <h1 style={{ margin: '0 0 6px', fontSize: 22 }}>
+        Toast — Auto-dismiss timer
+      </h1>
+      <p style={{ margin: '0 0 20px', fontSize: 13, color: '#555555', maxWidth: 560 }}>
+        Each toast dismisses itself after {AUTO_DISMISS_TIMEOUT_MS / 1000} seconds, counted
+        down by the timer bar across the top of the toast. Hover the toast to freeze the
+        countdown — every toast in the stack pauses, and they all resume from where they
+        left off once the cursor leaves.
+      </p>
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button type="button" onClick={showToast}>
+          Show timed toast
+        </button>
+        <button type="button" onClick={showToastStack}>
+          Show 3 timed toasts
+        </button>
+      </div>
+
+      <CourierToast
+        autoDismiss
+        autoDismissTimeoutMs={AUTO_DISMISS_TIMEOUT_MS}
+      />
+    </div>
+  );
+}

--- a/examples/react-latest/src/App.tsx
+++ b/examples/react-latest/src/App.tsx
@@ -17,6 +17,7 @@ import MarkdownListItemInbox from './MarkdownListItem';
 import ToastBasic from './ToastBasic';
 import ToastThemed from './ToastThemed';
 import ToastCustom from './ToastCustom';
+import ToastAutoDismiss from './ToastAutoDismiss';
 import Hooks from './Hooks';
 import InboxCustomFeed from './InboxCustomFeed';
 import InboxCustomTabs from './InboxCustomTabs';
@@ -72,6 +73,7 @@ function App() {
         <Route path="/examples/toast-basic" element={<ToastBasic />} />
         <Route path="/examples/toast-themed" element={<ToastThemed />} />
         <Route path="/examples/toast-custom" element={<ToastCustom />} />
+        <Route path="/examples/toast-auto-dismiss" element={<ToastAutoDismiss />} />
         <Route path="/examples/toast" element={<ToastCustom />} />
         <Route path="/examples/hooks" element={<Hooks />} />
 

--- a/examples/react-latest/src/Examples.tsx
+++ b/examples/react-latest/src/Examples.tsx
@@ -129,6 +129,9 @@ export default function Examples() {
           <ExampleCard to="/examples/toast-custom" title="Toast — Custom">
             Toast notifications rendered with a fully custom React component.
           </ExampleCard>
+          <ExampleCard to="/examples/toast-auto-dismiss" title="Toast — Auto-dismiss">
+            Timed toasts with a countdown bar that pauses while hovered.
+          </ExampleCard>
         </div>
 
         {/* Preferences examples */}

--- a/examples/react-latest/src/ToastAutoDismiss.tsx
+++ b/examples/react-latest/src/ToastAutoDismiss.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import { CourierToast, useCourier } from '@trycourier/courier-react';
+
+const AUTO_DISMISS_TIMEOUT_MS = 6000;
+
+export default function ToastAutoDismiss() {
+  const courier = useCourier();
+
+  // Toasts are matched to messages by id, so each one needs a distinct id.
+  const count = useRef(0);
+
+  useEffect(() => {
+    courier.shared.signIn({
+      userId: import.meta.env.VITE_USER_ID,
+      jwt: import.meta.env.VITE_JWT,
+    });
+  }, []);
+
+  const showToast = () => {
+    count.current += 1;
+    courier.toast.addMessage({
+      messageId: `auto-dismiss-${count.current}`,
+      title: `📸 New photos from Fred L. (${count.current})`,
+      body: 'Fred shared 4 photos.',
+      actions: [
+        { content: 'See more' },
+        { content: 'Mark read' },
+      ],
+    });
+  };
+
+  const showToastStack = () => {
+    showToast();
+    showToast();
+    showToast();
+  };
+
+  return (
+    <div
+      style={{
+        margin: 0,
+        minHeight: '100vh',
+        padding: 40,
+        boxSizing: 'border-box',
+        background: 'white',
+        fontFamily:
+          "-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",
+      }}
+    >
+      <h1 style={{ margin: '0 0 6px', fontSize: 22 }}>
+        Toast — Auto-dismiss timer
+      </h1>
+      <p style={{ margin: '0 0 20px', fontSize: 13, color: '#555555', maxWidth: 560 }}>
+        Each toast dismisses itself after {AUTO_DISMISS_TIMEOUT_MS / 1000} seconds, counted
+        down by the timer bar across the top of the toast. Hover the toast to freeze the
+        countdown — every toast in the stack pauses, and they all resume from where they
+        left off once the cursor leaves.
+      </p>
+
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button type="button" onClick={showToast}>
+          Show timed toast
+        </button>
+        <button type="button" onClick={showToastStack}>
+          Show 3 timed toasts
+        </button>
+      </div>
+
+      <CourierToast
+        autoDismiss
+        autoDismissTimeoutMs={AUTO_DISMISS_TIMEOUT_MS}
+      />
+    </div>
+  );
+}

--- a/examples/vue/src/Examples.vue
+++ b/examples/vue/src/Examples.vue
@@ -50,6 +50,7 @@ const toastExamples: ExampleCard[] = [
   { to: '/examples/toast-basic', title: 'Toast — Basic', description: 'Toast notifications using the default Courier Toast theme.' },
   { to: '/examples/toast-themed', title: 'Toast — Themed', description: 'Toast notifications using a Poppins-based custom theme.' },
   { to: '/examples/toast-custom', title: 'Toast — Custom', description: 'Toast notifications rendered with a fully custom Vue component.' },
+  { to: '/examples/toast-auto-dismiss', title: 'Toast — Auto-dismiss', description: 'Timed toasts with a countdown bar that pauses while hovered.' },
 ];
 
 const preferencesExamples: ExampleCard[] = [

--- a/examples/vue/src/ToastAutoDismiss.vue
+++ b/examples/vue/src/ToastAutoDismiss.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { CourierToast, useCourier } from '@trycourier/courier-vue';
+
+const AUTO_DISMISS_TIMEOUT_MS = 6000;
+
+const courier = useCourier();
+
+onMounted(() => {
+  courier.shared.signIn({
+    userId: import.meta.env.VITE_USER_ID,
+    jwt: import.meta.env.VITE_JWT,
+  });
+});
+
+// Toasts are matched to messages by id, so each one needs a distinct id.
+let count = 0;
+
+const showToast = () => {
+  count += 1;
+  courier.toast.value.addMessage({
+    messageId: `auto-dismiss-${count}`,
+    title: `📸 New photos from Fred L. (${count})`,
+    body: 'Fred shared 4 photos.',
+    actions: [{ content: 'See more' }, { content: 'Mark read' }],
+  });
+};
+
+const showToastStack = () => {
+  showToast();
+  showToast();
+  showToast();
+};
+</script>
+
+<template>
+  <div
+    :style="{
+      margin: 0,
+      minHeight: '100vh',
+      padding: '40px',
+      boxSizing: 'border-box',
+      background: 'white',
+      fontFamily: `-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif`,
+    }"
+  >
+    <h1 :style="{ margin: '0 0 6px', fontSize: '22px' }">Toast — Auto-dismiss timer</h1>
+    <p :style="{ margin: '0 0 20px', fontSize: '13px', color: '#555555', maxWidth: '560px' }">
+      Each toast dismisses itself after {{ AUTO_DISMISS_TIMEOUT_MS / 1000 }} seconds, counted
+      down by the timer bar across the top of the toast. Hover the toast to freeze the
+      countdown — every toast in the stack pauses, and they all resume from where they left
+      off once the cursor leaves.
+    </p>
+
+    <div :style="{ display: 'flex', gap: '8px' }">
+      <button type="button" @click="showToast">Show timed toast</button>
+      <button type="button" @click="showToastStack">Show 3 timed toasts</button>
+    </div>
+
+    <CourierToast auto-dismiss :auto-dismiss-timeout-ms="AUTO_DISMISS_TIMEOUT_MS" />
+  </div>
+</template>

--- a/examples/vue/src/router.ts
+++ b/examples/vue/src/router.ts
@@ -19,6 +19,7 @@ import MarkdownListItem from './MarkdownListItem.vue';
 import ToastBasic from './ToastBasic.vue';
 import ToastThemed from './ToastThemed.vue';
 import ToastCustom from './ToastCustom.vue';
+import ToastAutoDismiss from './ToastAutoDismiss.vue';
 import Hooks from './Hooks.vue';
 import InboxCustomFeed from './InboxCustomFeed.vue';
 import InboxCustomTabs from './InboxCustomTabs.vue';
@@ -72,6 +73,7 @@ export const router = createRouter({
     { path: '/examples/toast-basic', component: ToastBasic },
     { path: '/examples/toast-themed', component: ToastThemed },
     { path: '/examples/toast-custom', component: ToastCustom },
+    { path: '/examples/toast-auto-dismiss', component: ToastAutoDismiss },
     { path: '/examples/toast', component: ToastCustom },
     { path: '/examples/hooks', component: Hooks },
 

--- a/examples/web-js/examples.html
+++ b/examples/web-js/examples.html
@@ -103,6 +103,10 @@
           <strong>Toast — Themed</strong>
           <span>Toast notifications using a custom theme.</span>
         </a>
+        <a class="example-card" href="/examples/toast-auto-dismiss">
+          <strong>Toast — Auto-dismiss</strong>
+          <span>Timed toasts with a countdown bar that pauses while hovered.</span>
+        </a>
       </div>
 
       <div class="examples-column">

--- a/examples/web-js/examples/toast-auto-dismiss.html
+++ b/examples/web-js/examples/toast-auto-dismiss.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>web-js</title>
+  <link rel="stylesheet" href="../styles.css">
+</head>
+
+<body>
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: white;
+      min-height: 100vh;
+      padding: 40px;
+      box-sizing: border-box;
+    }
+
+    h1 {
+      margin: 0 0 6px;
+      font-size: 22px;
+    }
+
+    .description {
+      margin: 0 0 20px;
+      font-size: 13px;
+      color: #555555;
+      max-width: 560px;
+    }
+
+    .buttons {
+      display: flex;
+      gap: 8px;
+    }
+  </style>
+
+  <h1>Toast — Auto-dismiss timer</h1>
+  <p class="description">
+    Each toast dismisses itself after 6 seconds, counted down by the timer bar across the top
+    of the toast. Hover the toast to freeze the countdown — every toast in the stack pauses,
+    and they all resume from where they left off once the cursor leaves.
+  </p>
+
+  <div class="buttons">
+    <button id="show-toast-button">Show timed toast</button>
+    <button id="show-toast-stack-button">Show 3 timed toasts</button>
+  </div>
+
+  <!-- Auto-dismiss and its timeout can also be set in JS:
+       toast.enableAutoDismiss() / toast.setAutoDismissTimeoutMs(6000) -->
+  <courier-toast id="my-toast" auto-dismiss auto-dismiss-timeout-ms="6000"></courier-toast>
+
+  <script type="module">
+    import { Courier, CourierToastDatastore } from '@trycourier/courier-ui-toast';
+
+    // Authenticate the user with Courier
+    Courier.shared.signIn({
+      userId: import.meta.env.VITE_USER_ID,
+      jwt: import.meta.env.VITE_JWT,
+    });
+
+    // Toasts are matched to messages by id, so each one needs a distinct id.
+    let count = 0;
+
+    const showToast = () => {
+      count++;
+      CourierToastDatastore.shared.addMessage({
+        messageId: `auto-dismiss-${count}`,
+        title: `📸 New photos from Fred L. (${count})`,
+        body: "Fred shared 4 photos.",
+        actions: [
+          {
+            content: "See more"
+          },
+          {
+            content: "Mark read"
+          }
+        ]
+      });
+    };
+
+    document.getElementById("show-toast-button").addEventListener("click", showToast);
+    document.getElementById("show-toast-stack-button").addEventListener("click", () => {
+      showToast();
+      showToast();
+      showToast();
+    });
+  </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
## What

Hover-to-pause shipped in #220 (released in `@trycourier/courier-ui-toast@2.1.10`), but the countdown was owned by each `CourierToastItem`. That left three gaps you hit in normal use:

1. **A new toast un-froze the one you were reading.** When a second toast arrived on top of a hovered one, the hovered item was pushed down the stack and got `mouseleave` — so it resumed and dismissed itself, with the cursor never having left the toast.
2. **Only the toast under the cursor froze.** In a stack, the toasts queued behind burned their countdowns down and vanished while you read the top one — you never saw them.
3. **Custom items never paused.** `setToastItem` items used a plain `setTimeout` with no pause path at all.

Hover now belongs to the `CourierToast` container, which is a single hover surface for the whole stack: `mouseenter` pauses every item's countdown, `mouseleave` resumes them all from where they left off, and a toast that lands while the cursor is already over the stack starts out paused. Timer bookkeeping moved into a small `PausableTimeout` shared by `CourierToastItem` and the custom-item path.

Also fixes a latent throw on the custom-item path: a pending auto-dismiss called `this.removeChild(customItem)` even if the item was already removed (e.g. via `dismissToastForMessage`). It now cancels on removal and uses `customItem.remove()`.

## Examples: the timer wasn't reachable

`autoDismiss` defaults to `false` and **no example enabled it**, so neither the countdown bar nor the hover pause could be seen in any demo app — which is why this slipped through. Adds a **Toast — Auto-dismiss** demo (6s timer + a "Show 3 timed toasts" button for the stack case) at `/examples/toast-auto-dismiss` in `web-js`, `react-latest`, `react-17`, `vue`, `angular`, and `next-latest`, registered in each app's router and index page.

## Testing

Driven in headless Chrome over CDP with real synthesized mouse events, against both the vanilla (`web-js`) and React (`react-latest`) examples:

| Scenario | Before | After |
| --- | --- | --- |
| Hover a single toast | pauses ✅ | pauses ✅ |
| Cursor parked where the toast appears | pauses ✅ | pauses ✅ |
| New toast arrives while hovering | old item resumes + dismisses ❌ | both stay paused ✅ |
| Hover top of a 3-deep stack | items 1 & 2 dismiss underneath ❌ | all 3 frozen ✅ |
| Cursor leaves | resumes ✅ | all resume from banked time, then dismiss ✅ |

Unit tests: 61/61 pass in `courier-ui-toast`, with hover coverage extended to the stack case, the new-toast-arrives case, cursor-already-parked, resume-from-banked-time, and custom items. `api/courier-ui-toast.api.md` regenerated — the only delta is the two new `CourierToastItem` methods.

Pre-existing and untouched by this PR: `react-17`'s `tsc` fails with `TS2786` on every page (including untouched ones like `ToastBasic.tsx`), and `react-latest` has 7 errors in `CustomMenuButton.tsx`/`CustomOther.tsx`/`PreferencesStyled.tsx`.

No changeset — added separately.

## Also: `AGENTS.md`

The repo had `.agents/skills/` but no root entry point, so the build/test/API-report workflows (and the fact that packages resolve each other through built `dist/`) had to be discovered by trial and error. Adds `AGENTS.md` (with `CLAUDE.md` as a symlink, matching the existing `.claude/skills` → `.agents/skills` link): layout, commands, the skill index, and the conventions a component change should follow — including that **this repo is public**, so internal-only material doesn't belong in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)