### PR TITLE
chore: add changeset for the toast hover-pause stack fix

### DIFF
--- a/.changeset/quiet-lamps-wander.md
+++ b/.changeset/quiet-lamps-wander.md
@@ -1,0 +1,5 @@
+---
+"@trycourier/courier-ui-toast": patch
+---
+
+Toast hover-to-pause now covers the whole stack: a new toast arriving on top of a hovered one no longer resumes its countdown, toasts queued behind the top one stay frozen while it's being read, and custom toast items pause too.


### PR DESCRIPTION
## Why

#222 merged without a changeset. With no pending changeset, `changeset publish` had nothing to bump and tried to re-publish the versions already on npm, so the Release run failed on all 10 packages:

```
No changesets found. Attempting to publish any unpublished packages to npm
npm error You cannot publish over the previously published versions: 2.1.10.
packages failed to publish:  @trycourier/courier-ui-toast@2.1.10  (+ 9 others)
```

([run 30127863348](https://github.com/trycourier/courier-web/actions/runs/30127863348))

Net effect: the fix is on `main`, but `@trycourier/courier-ui-toast@latest` on npm is still **2.1.10** — the pre-fix build from #220 — so consumers still have the bug.

## What this does

Adds the missing patch changeset for `@trycourier/courier-ui-toast`. `yarn changeset status --verbose` on this branch:

```
Packages to be bumped at patch
- @trycourier/courier-ui-toast 2.1.11
  - .changeset/quiet-lamps-wander.md
- @trycourier/courier-angular 1.0.4
- @trycourier/courier-react 9.2.7
- @trycourier/courier-react-17 9.2.7
- @trycourier/courier-react-components 2.2.7
- @trycourier/courier-vue 1.0.4
```

Only `courier-ui-toast` is listed in the changeset — the rest are `updateInternalDependencies: patch` cascades that changesets applies at version time.

Merging this opens a "Version Packages" PR; merging **that** publishes 2.1.11.

## Note on the earlier red run

"Version Packages (#221)" also shows a failure, but that one **did** publish — npm has 2.1.10 and its siblings. It exited non-zero because a subset of packages reported "already published" within the same run. Don't confuse it with the run above, which published nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)