### PR TITLE
Designer: template-id switcher (+ query params) & staging inbox socket URL fix

### DIFF
--- a/designer/app/api/messages/route.ts
+++ b/designer/app/api/messages/route.ts
@@ -8,9 +8,10 @@ interface MessageAction {
 
 export async function POST(request: Request) {
   try {
-    // Read user_id, title, body, optional tags, optional actions, optional api_key, and courierRest from request body
+    // Read user_id and either a template id or inline title/body, plus optional
+    // data, tags, actions, api_key, and courierRest from request body
     const body = await request.json();
-    const { user_id, title, body: messageBody, tags, actions, api_key, courierRest } = body;
+    const { user_id, title, body: messageBody, template, data, tags, actions, api_key, courierRest } = body;
 
     if (!user_id) {
       return NextResponse.json(
@@ -19,53 +20,58 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!title) {
-      return NextResponse.json(
-        { error: 'title is required in request body' },
-        { status: 400 }
-      );
-    }
+    if (!template) {
+      if (!title) {
+        return NextResponse.json(
+          { error: 'title is required in request body' },
+          { status: 400 }
+        );
+      }
 
-    if (!messageBody) {
-      return NextResponse.json(
-        { error: 'body is required in request body' },
-        { status: 400 }
-      );
+      if (!messageBody) {
+        return NextResponse.json(
+          { error: 'body is required in request body' },
+          { status: 400 }
+        );
+      }
     }
 
     // Use provided api_key or fall back to environment default
     const courier = getCourierClient(courierRest, api_key);
 
-    // Build the content - use Elemental format if actions are provided
+    // Prefer a template id over inline content when provided
     let content: any;
-    if (actions && Array.isArray(actions) && actions.length > 0) {
-      // Use Elemental content format to include actions
-      const elements: any[] = [
-        { type: 'meta', title: title },
-        { type: 'text', content: messageBody },
-      ];
+    if (!template) {
+      // Build the content - use Elemental format if actions are provided
+      if (actions && Array.isArray(actions) && actions.length > 0) {
+        // Use Elemental content format to include actions
+        const elements: any[] = [
+          { type: 'meta', title: title },
+          { type: 'text', content: messageBody },
+        ];
 
-      // Add action elements
-      actions.forEach((action: MessageAction) => {
-        if (action.content && action.href) {
-          elements.push({
-            type: 'action',
-            content: action.content,
-            href: action.href,
-          });
-        }
-      });
+        // Add action elements
+        actions.forEach((action: MessageAction) => {
+          if (action.content && action.href) {
+            elements.push({
+              type: 'action',
+              content: action.content,
+              href: action.href,
+            });
+          }
+        });
 
-      content = {
-        version: '2022-01-01',
-        elements,
-      };
-    } else {
-      // Use simple title/body format when no actions
-      content = {
-        title: title,
-        body: messageBody,
-      };
+        content = {
+          version: '2022-01-01',
+          elements,
+        };
+      } else {
+        // Use simple title/body format when no actions
+        content = {
+          title: title,
+          body: messageBody,
+        };
+      }
     }
 
     // Send inbox message to the user
@@ -74,7 +80,8 @@ export async function POST(request: Request) {
         to: {
           user_id: user_id,
         },
-        content,
+        ...(template ? { template } : { content }),
+        ...(data && Object.keys(data).length > 0 && { data }),
         metadata: {
           tags: tags,
         },

--- a/designer/app/lib/api-urls.ts
+++ b/designer/app/lib/api-urls.ts
@@ -38,7 +38,10 @@ export const API_ENVIRONMENT_PRESETS: Record<Exclude<ApiEnvironment, 'custom'>, 
     },
     inbox: {
       graphql: 'https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q',
-      webSocket: 'http://inbox-staging-ws-alb-490231599.us-east-1.elb.amazonaws.com',
+      // Cloudflare-fronted realtime vanity (TLS), mirrors prod's realtime.courier.io.
+      // The raw `inbox-staging-ws-alb-*.elb.amazonaws.com` ELB has no browser-valid
+      // TLS cert and 301-redirects on http, so a browser WebSocket can't connect to it.
+      webSocket: 'wss://realtime.courierstaging.com',
     },
   },
   dev: {

--- a/designer/app/lib/courier-repo.ts
+++ b/designer/app/lib/courier-repo.ts
@@ -16,6 +16,22 @@ export interface MessageAction {
   href: string;
 }
 
+export interface SendMessageOptions {
+  userId: string;
+  /** Inline content title (ignored when `templateId` is set). */
+  title?: string;
+  /** Inline content body (ignored when `templateId` is set). */
+  body?: string;
+  /** Template/notification id to send instead of inline title/body. */
+  templateId?: string;
+  /** Template variables / message data. */
+  data?: Record<string, string>;
+  tags?: string[];
+  actions?: MessageAction[];
+  apiKey?: string;
+  courierRest?: string;
+}
+
 export interface GenerateJWTIssueTokenOptions {
   /** JWT scope string; omitted or empty → server default scope for user_id */
   scope?: string;
@@ -75,15 +91,19 @@ export class CourierRepo {
     return response.json();
   }
 
-  async sendMessage(
-    userId: string,
-    title: string,
-    body: string,
-    tags?: string[],
-    actions?: MessageAction[],
-    apiKey?: string,
-    courierRest?: string
-  ): Promise<SendMessageResponse> {
+  async sendMessage(options: SendMessageOptions): Promise<SendMessageResponse> {
+    const {
+      userId,
+      title,
+      body,
+      templateId,
+      data,
+      tags,
+      actions,
+      apiKey,
+      courierRest,
+    } = options;
+
     const response = await fetch("/inbox-demo/api/messages", {
       method: "POST",
       headers: {
@@ -91,8 +111,8 @@ export class CourierRepo {
       },
       body: JSON.stringify({
         user_id: userId,
-        title,
-        body,
+        ...(templateId ? { template: templateId } : { title, body }),
+        ...(data && Object.keys(data).length > 0 && { data }),
         tags,
         actions,
         ...(apiKey && { api_key: apiKey }),

--- a/designer/app/page.tsx
+++ b/designer/app/page.tsx
@@ -105,6 +105,10 @@ function HomeContent() {
   const topicId = searchParams.get('topicId') || undefined;
   const clientKey = searchParams.get('clientKey') || undefined;
 
+  // Send-test form: message mode ('content' | 'template') and template id
+  const sendMode = searchParams.get('sendMode') === 'template' ? 'template' : 'content';
+  const templateId = searchParams.get('template') || '';
+
   // Helper to update URL params
   const updateUrlParams = useCallback((key: string, value: string, defaultValue: string) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -128,6 +132,15 @@ function HomeContent() {
     updateUrlParams('layout', tab, DEFAULT_RIGHT_TAB);
   }, [updateUrlParams]);
   const visibleRightTab = activeRightTab;
+
+  // Persist the send-test mode / template id to the URL (shareable deep links)
+  const handleSendModeChange = useCallback((mode: 'content' | 'template') => {
+    updateUrlParams('sendMode', mode, 'content');
+  }, [updateUrlParams]);
+
+  const handleTemplateIdChange = useCallback((id: string) => {
+    updateUrlParams('template', id, '');
+  }, [updateUrlParams]);
 
   // Apply color mode to the page
   useEffect(() => {
@@ -237,7 +250,15 @@ function HomeContent() {
       </div>
       <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
         <TabsContent value="send-test" className="mt-0 flex-1 min-h-0 overflow-hidden flex flex-col">
-          <SendTestTab userId={userId} apiKey={overrideApiKey} courierRest={courierRest} />
+          <SendTestTab
+            userId={userId}
+            apiKey={overrideApiKey}
+            courierRest={courierRest}
+            sendMode={sendMode}
+            templateId={templateId}
+            onSendModeChange={handleSendModeChange}
+            onTemplateIdChange={handleTemplateIdChange}
+          />
         </TabsContent>
         <TabsContent value="theme" className="mt-0 flex-1 min-h-0 overflow-hidden flex flex-col">
           <ThemeTab

--- a/designer/components/SendMessageForm.tsx
+++ b/designer/components/SendMessageForm.tsx
@@ -12,11 +12,20 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface SendMessageFormProps {
   userId: string;
   apiKey?: string;
   courierRest?: string;
+  /** Initial send mode, from the `sendMode` query param. */
+  sendMode?: SendMode;
+  /** Initial template id, from the `template` query param. */
+  templateId?: string;
+  /** Persist the active send mode to the URL. */
+  onSendModeChange?: (mode: SendMode) => void;
+  /** Persist the template id to the URL. */
+  onTemplateIdChange?: (templateId: string) => void;
 }
 
 interface ActionField {
@@ -31,20 +40,47 @@ interface VariableField {
   value: string;
 }
 
+type SendMode = 'content' | 'template';
+
 interface HistoryItem {
+  mode: SendMode;
   title: string;
   body: string;
+  templateId: string;
   tags: string;
   actions: { content: string; href: string }[];
   variables: { key: string; value: string }[];
 }
 
-export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageFormProps) {
+export function SendMessageForm({
+  userId,
+  apiKey,
+  courierRest,
+  sendMode,
+  templateId: initialTemplateId,
+  onSendModeChange,
+  onTemplateIdChange,
+}: SendMessageFormProps) {
   const [isSendingMessage, setIsSendingMessage] = useState(false);
   const [sendMessageError, setSendMessageError] = useState<string | null>(null);
+  const [mode, setMode] = useState<SendMode>(sendMode ?? 'content');
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
+  const [templateId, setTemplateId] = useState(initialTemplateId ?? '');
   const [tags, setTags] = useState('');
+
+  // `sendMode`/`initialTemplateId` seed the initial state from the URL on mount.
+  // After that, local state is the source of truth (so the input stays
+  // responsive); changes are mirrored back to the URL via the callbacks below.
+  const changeMode = (next: SendMode) => {
+    setMode(next);
+    onSendModeChange?.(next);
+  };
+
+  const changeTemplateId = (next: string) => {
+    setTemplateId(next);
+    onTemplateIdChange?.(next);
+  };
   const [actions, setActions] = useState<ActionField[]>([]);
   const [variables, setVariables] = useState<VariableField[]>([]);
   const [history, setHistory] = useState<HistoryItem[]>([]);
@@ -53,8 +89,10 @@ export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageForm
   const MAX_HISTORY = 20;
 
   const applyHistoryItem = (item: HistoryItem) => {
+    changeMode(item.mode);
     setTitle(item.title);
     setBody(item.body);
+    changeTemplateId(item.templateId);
     setTags(item.tags);
     setActions(
       item.actions.map((a) => ({
@@ -115,31 +153,44 @@ export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageForm
         .filter(v => v.key.trim() !== '')
         .forEach(v => { varsRecord[v.key.trim()] = v.value; });
 
-      let resolvedTitle = substituteVariables(title.trim(), varsRecord);
-      let resolvedBody = substituteVariables(body.trim(), varsRecord);
-      resolvedBody = markdownLinksToHtml(resolvedBody);
+      if (mode === 'template') {
+        await repo.sendMessage({
+          userId,
+          templateId: templateId.trim(),
+          data: varsRecord,
+          tags: tagsArray.length > 0 ? tagsArray : undefined,
+          apiKey,
+          courierRest,
+        });
+      } else {
+        let resolvedTitle = substituteVariables(title.trim(), varsRecord);
+        let resolvedBody = substituteVariables(body.trim(), varsRecord);
+        resolvedBody = markdownLinksToHtml(resolvedBody);
 
-      const validActions: MessageAction[] = actions
-        .filter(action => action.content.trim() && action.href.trim())
-        .map(action => ({
-          content: substituteVariables(action.content.trim(), varsRecord),
-          href: substituteVariablesRaw(action.href.trim(), varsRecord),
-        }));
+        const validActions: MessageAction[] = actions
+          .filter(action => action.content.trim() && action.href.trim())
+          .map(action => ({
+            content: substituteVariables(action.content.trim(), varsRecord),
+            href: substituteVariablesRaw(action.href.trim(), varsRecord),
+          }));
 
-      await repo.sendMessage(
-        userId,
-        resolvedTitle,
-        resolvedBody,
-        tagsArray.length > 0 ? tagsArray : undefined,
-        validActions.length > 0 ? validActions : undefined,
-        apiKey,
-        courierRest
-      );
+        await repo.sendMessage({
+          userId,
+          title: resolvedTitle,
+          body: resolvedBody,
+          tags: tagsArray.length > 0 ? tagsArray : undefined,
+          actions: validActions.length > 0 ? validActions : undefined,
+          apiKey,
+          courierRest,
+        });
+      }
       setHistory((prev) => {
         const next = [
           {
+            mode,
             title: title.trim(),
             body: body.trim(),
+            templateId: templateId.trim(),
             tags,
             actions: actions.map((a) => ({ content: a.content, href: a.href })),
             variables: variables.map((v) => ({ key: v.key, value: v.value })),
@@ -150,6 +201,7 @@ export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageForm
       });
       setTitle('');
       setBody('');
+      changeTemplateId('');
       setTags('');
       setActions([]);
       setVariables([]);
@@ -165,36 +217,62 @@ export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageForm
   return (
     <div className="p-4 h-full overflow-y-auto">
       <form onSubmit={handleSendMessage} className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="title">Title</Label>
-          <Textarea
-            id="title"
-            value={title}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setTitle(e.target.value)}
-            required
-            rows={2}
-            placeholder="Enter message title"
-            className="font-mono"
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="body">Body</Label>
-          <Textarea
-            id="body"
-            value={body}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.target.value)}
-            required
-            rows={3}
-            placeholder="Enter message body"
-            className="font-mono"
-          />
-          <p className="text-xs text-muted-foreground">
-            Links: <code className="bg-muted px-1 rounded">[text](https://example.com)</code>
-          </p>
-          <p className="text-xs text-muted-foreground">
-            Variables: <code className="bg-muted px-1 rounded">{'{{name}}'}</code>
-          </p>
-        </div>
+        <Tabs value={mode} onValueChange={(v: string) => changeMode(v as SendMode)}>
+          <TabsList className="w-full">
+            <TabsTrigger value="content" className="flex-1">Content</TabsTrigger>
+            <TabsTrigger value="template" className="flex-1">Template</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        {mode === 'content' ? (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor="title">Title</Label>
+              <Textarea
+                id="title"
+                value={title}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setTitle(e.target.value)}
+                required
+                rows={2}
+                placeholder="Enter message title"
+                className="font-mono"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="body">Body</Label>
+              <Textarea
+                id="body"
+                value={body}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.target.value)}
+                required
+                rows={3}
+                placeholder="Enter message body"
+                className="font-mono"
+              />
+              <p className="text-xs text-muted-foreground">
+                Links: <code className="bg-muted px-1 rounded">[text](https://example.com)</code>
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Variables: <code className="bg-muted px-1 rounded">{'{{name}}'}</code>
+              </p>
+            </div>
+          </>
+        ) : (
+          <div className="space-y-2">
+            <Label htmlFor="templateId">Template ID</Label>
+            <Input
+              id="templateId"
+              type="text"
+              value={templateId}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => changeTemplateId(e.target.value)}
+              required
+              placeholder="e.g., WELCOME_INBOX or a notification id"
+              className="font-mono"
+            />
+            <p className="text-xs text-muted-foreground">
+              Sends a saved template instead of inline content. Variables below are passed as the message <code className="bg-muted px-1 rounded">data</code>.
+            </p>
+          </div>
+        )}
         <hr className="border-border my-4" />
         <div className="space-y-2">
           <Label htmlFor="tags">
@@ -251,6 +329,7 @@ export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageForm
             </div>
           ))}
         </div>
+        {mode === 'content' && (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <Label>
@@ -299,11 +378,17 @@ export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageForm
             </div>
           ))}
         </div>
+        )}
         <hr className="border-border my-4" />
         <div>
           <Button
             type="submit"
-            disabled={isSendingMessage || !title.trim() || !body.trim()}
+            disabled={
+              isSendingMessage ||
+              (mode === 'template'
+                ? !templateId.trim()
+                : !title.trim() || !body.trim())
+            }
           >
             {isSendingMessage ? 'Sending...' : 'Send'}
           </Button>
@@ -329,12 +414,25 @@ export function SendMessageForm({ userId, apiKey, courierRest }: SendMessageForm
                     type="button"
                     onClick={() => applyHistoryItem(item)}
                     className="w-full text-left px-3 py-2 rounded-md border border-border bg-muted/20 hover:bg-muted/40 text-sm font-mono transition-colors space-y-0.5"
-                    title={item.body || item.title || '(empty)'}
+                    title={
+                      item.mode === 'template'
+                        ? item.templateId || '(no template)'
+                        : item.body || item.title || '(empty)'
+                    }
                   >
-                    <div className="font-medium truncate">{item.title || '(no title)'}</div>
-                    <div className="text-muted-foreground text-xs line-clamp-2 break-words">
-                      {item.body || '(no body)'}
-                    </div>
+                    {item.mode === 'template' ? (
+                      <div className="font-medium truncate">
+                        <span className="text-muted-foreground">Template:</span>{' '}
+                        {item.templateId || '(no template)'}
+                      </div>
+                    ) : (
+                      <>
+                        <div className="font-medium truncate">{item.title || '(no title)'}</div>
+                        <div className="text-muted-foreground text-xs line-clamp-2 break-words">
+                          {item.body || '(no body)'}
+                        </div>
+                      </>
+                    )}
                   </button>
                 </li>
               ))}

--- a/designer/components/SendTestTab.tsx
+++ b/designer/components/SendTestTab.tsx
@@ -3,17 +3,39 @@
 import { SendMessageForm } from './SendMessageForm';
 import { TabFooter } from './TabFooter';
 
+type SendMode = 'content' | 'template';
+
 interface SendTestTabProps {
   userId: string;
   apiKey?: string;
   courierRest?: string;
+  sendMode?: SendMode;
+  templateId?: string;
+  onSendModeChange?: (mode: SendMode) => void;
+  onTemplateIdChange?: (templateId: string) => void;
 }
 
-export function SendTestTab({ userId, apiKey, courierRest }: SendTestTabProps) {
+export function SendTestTab({
+  userId,
+  apiKey,
+  courierRest,
+  sendMode,
+  templateId,
+  onSendModeChange,
+  onTemplateIdChange,
+}: SendTestTabProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto min-h-0">
-        <SendMessageForm userId={userId} apiKey={apiKey} courierRest={courierRest} />
+        <SendMessageForm
+          userId={userId}
+          apiKey={apiKey}
+          courierRest={courierRest}
+          sendMode={sendMode}
+          templateId={templateId}
+          onSendModeChange={onSendModeChange}
+          onTemplateIdChange={onTemplateIdChange}
+        />
       </div>
       <div className="flex-shrink-0 border-t border-border p-4">
         <TabFooter


### PR DESCRIPTION
Two independent designer (inbox-demo) changes.

## 1. Template-id switcher + query-param support (`da6d021`)
Adds a **Content / Template** switcher to the Send form:
- **Content** (default): existing Title + Body + Actions inline-content flow, unchanged.
- **Template**: takes a **template (notification) id** and passes the Variables as the message `data`; the API route sends `message.template` instead of inline `content`.
- Mode + template id are reflected in the URL (`?sendMode=template&template=<id>`) so a configured send is shareable / deep-linkable, following the app's existing param convention (`env`, `apiKey`, `tab`).

Files: `SendMessageForm.tsx`, `courier-repo.ts` (`sendMessage` now takes an options object), `api/messages/route.ts` (template branch), `SendTestTab.tsx`, `page.tsx` (param read + URL writers).

Verified end-to-end on prod + dev: content send renders in the inbox; a template send is accepted and recorded by Courier as a template/event lookup (no title/body required). Deep-link prefill and URL round-trip confirmed in the browser. `tsc --noEmit` clean.

## 2. Staging inbox socket URL fix (`a4d7d92`)
The staging `inbox.webSocket` pointed at the raw internal ELB `http://inbox-staging-ws-alb-*.elb.amazonaws.com`, which:
- 301-redirects on `http://` — and a WebSocket handshake cannot follow redirects, so it aborts into the SDK's 30s–8min retry backoff; and
- has no browser-valid TLS cert over `wss://`.

Repointed to `wss://realtime.courierstaging.com` — the Cloudflare-fronted realtime vanity from `services/apps/inbox/cdk.json`, mirroring prod's `realtime.courier.io`. Verified at the network layer (valid TLS, same 404-on-bare-GET behavior as prod).

## Not included
Dev realtime is separately broken (the new inbox service never receives publishes on dev — CPP's forward-to-services bridge is a no-op on dev). That's a backend/CPP fix tracked in **C-19635**, not a courier-web change; the designer's dev socket URL is intentionally left as-is until there's a working `wss://` dev endpoint to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)