### PR TITLE
Designer: load API environments from a config endpoint

### DIFF
--- a/designer/.env.example
+++ b/designer/.env.example
@@ -1,0 +1,12 @@
+# Courier auth token used by the server routes (JWT issue + send).
+COURIER_AUTH_TOKEN=pk_prod_xxxxxxxxxxxxxxxxxxxxxxxx
+
+# Internal (non-public) API environments the inbox demo can target, returned by
+# GET /inbox-demo/api/env-urls. Kept OUT of this public repo — set here locally
+# and via the hosting platform's env (e.g. Vercel / GitHub secrets) when deployed.
+# Public production URLs are baked into the client and do NOT go here.
+#
+# JSON array; each entry: { id, label, apiUrls: { courier: { rest, graphql },
+# inbox: { graphql, webSocket } } }. Replace the example hosts below with the
+# real internal endpoints.
+INTERNAL_API_ENVIRONMENTS=[{"id":"staging","label":"Staging","apiUrls":{"courier":{"rest":"https://api.staging.example.com","graphql":"https://api.staging.example.com/client/q"},"inbox":{"graphql":"https://inbox.staging.example.com/q","webSocket":"wss://realtime.staging.example.com"}}},{"id":"dev","label":"Dev","apiUrls":{"courier":{"rest":"https://api.dev.example.com","graphql":"https://api.dev.example.com/client/q"},"inbox":{"graphql":"https://inbox.dev.example.com/q","webSocket":"wss://realtime.dev.example.com"}}}]

--- a/designer/.gitignore
+++ b/designer/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/designer/app/api/env-urls/route.ts
+++ b/designer/app/api/env-urls/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Returns the internal (non-public) API environments the inbox demo can target.
+ *
+ * These are kept OUT of this public repo. They are read from the server
+ * `INTERNAL_API_ENVIRONMENTS` env var (a JSON array) — set locally via the
+ * designer `.env`, and via the hosting platform's env (e.g. Vercel / GitHub
+ * secrets) when deployed. Public production URLs stay hard-coded on the client.
+ *
+ * Env var shape:
+ *   INTERNAL_API_ENVIRONMENTS=[
+ *     {"id":"staging","label":"Staging","apiUrls":{
+ *        "courier":{"rest":"...","graphql":"..."},
+ *        "inbox":{"graphql":"...","webSocket":"..."}}},
+ *     ...
+ *   ]
+ */
+
+interface CourierApiUrls {
+  courier: { rest: string; graphql: string };
+  inbox: { graphql: string; webSocket: string };
+}
+
+interface EnvironmentOption {
+  id: string;
+  label: string;
+  apiUrls: CourierApiUrls;
+}
+
+function isValidApiUrls(value: unknown): value is CourierApiUrls {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  const courier = v.courier as Record<string, unknown> | undefined;
+  const inbox = v.inbox as Record<string, unknown> | undefined;
+  return (
+    !!courier &&
+    typeof courier.rest === 'string' &&
+    typeof courier.graphql === 'string' &&
+    !!inbox &&
+    typeof inbox.graphql === 'string' &&
+    typeof inbox.webSocket === 'string'
+  );
+}
+
+export async function GET() {
+  const raw = process.env.INTERNAL_API_ENVIRONMENTS;
+  let environments: EnvironmentOption[] = [];
+
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        environments = parsed
+          .filter(
+            (e): e is EnvironmentOption =>
+              e && typeof e.id === 'string' && isValidApiUrls(e.apiUrls)
+          )
+          .map((e) => ({
+            id: e.id,
+            label: typeof e.label === 'string' && e.label ? e.label : e.id,
+            apiUrls: e.apiUrls,
+          }));
+      }
+    } catch {
+      // Invalid JSON — return no internal environments rather than 500ing.
+    }
+  }
+
+  return NextResponse.json({ environments });
+}

--- a/designer/app/lib/api-urls.ts
+++ b/designer/app/lib/api-urls.ts
@@ -5,12 +5,22 @@ type SearchParamsLike = {
 };
 
 export type ApiEnvironment = 'production' | 'production-eu' | 'staging' | 'dev' | 'custom';
+type PublicApiEnvironment = 'production' | 'production-eu';
 
 export const DEFAULT_API_ENVIRONMENT: ApiEnvironment = 'production';
 
 const VALID_ENVIRONMENTS: ApiEnvironment[] = ['production', 'production-eu', 'staging', 'dev', 'custom'];
 
-export const API_ENVIRONMENT_PRESETS: Record<Exclude<ApiEnvironment, 'custom'>, Readonly<CourierApiUrls>> = {
+/**
+ * Public, world-shippable environments — these URLs are already published in the
+ * SDK and docs, so it's fine to keep them in this public repo.
+ *
+ * Internal environments (staging/dev/…) are intentionally NOT stored here. They
+ * are served at runtime by `GET /inbox-demo/api/env-urls` from server env vars
+ * (see {@link loadInternalEnvironments}) so internal hostnames never land in
+ * this public repo.
+ */
+export const API_ENVIRONMENT_PRESETS: Record<PublicApiEnvironment, Readonly<CourierApiUrls>> = {
   production: {
     courier: {
       rest: 'https://api.courier.com',
@@ -31,29 +41,66 @@ export const API_ENVIRONMENT_PRESETS: Record<Exclude<ApiEnvironment, 'custom'>, 
       webSocket: 'wss://realtime.eu.courier.io',
     },
   },
-  staging: {
-    courier: {
-      rest: 'https://api.staging-trycourier.com',
-      graphql: 'https://yubmnstah4.execute-api.us-east-1.amazonaws.com/staging/client/q',
-    },
-    inbox: {
-      graphql: 'https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q',
-      // Cloudflare-fronted realtime vanity (TLS), mirrors prod's realtime.courier.io.
-      // The raw `inbox-staging-ws-alb-*.elb.amazonaws.com` ELB has no browser-valid
-      // TLS cert and 301-redirects on http, so a browser WebSocket can't connect to it.
-      webSocket: 'wss://realtime.courierstaging.com',
-    },
-  },
-  dev: {
-    courier: {
-      rest: 'https://api.courierdev.com',
-      graphql: 'https://api.courierdev.com/client/q',
-    },
-    inbox: {
-      graphql: 'https://inbox.courierdev.com/q',
-      webSocket: 'wss://9mrugsdnk1.execute-api.us-east-1.amazonaws.com/dev',
-    },
-  },
+};
+
+const PUBLIC_ENVIRONMENT_LABELS: Record<PublicApiEnvironment, string> = {
+  production: 'Production',
+  'production-eu': 'Production EU',
+};
+
+export interface ApiEnvironmentOption {
+  id: ApiEnvironment;
+  label: string;
+}
+
+const isPublicEnvironment = (env: string): env is PublicApiEnvironment =>
+  env === 'production' || env === 'production-eu';
+
+// --- Internal environments, fetched at runtime from the config endpoint -------
+
+interface InternalEnvironment {
+  id: string;
+  label: string;
+  apiUrls: CourierApiUrls;
+}
+
+let internalEnvironments: InternalEnvironment[] = [];
+let internalEnvironmentsLoaded = false;
+let internalEnvironmentsPromise: Promise<void> | null = null;
+
+const findInternalEnvironment = (env: string): InternalEnvironment | undefined =>
+  internalEnvironments.find((e) => e.id === env);
+
+/** True once the internal environment list has been fetched (or has failed) at least once. */
+export const areInternalEnvironmentsLoaded = (): boolean => internalEnvironmentsLoaded;
+
+/**
+ * Fetches the internal (non-public) API environments from the server config
+ * endpoint and caches them. Public prod/prod-eu URLs are baked into this file;
+ * everything else is served from server env so it never lands in this public
+ * repo. Runs at most once — safe to call repeatedly.
+ */
+export const loadInternalEnvironments = (): Promise<void> => {
+  if (internalEnvironmentsLoaded) return Promise.resolve();
+  if (internalEnvironmentsPromise) return internalEnvironmentsPromise;
+
+  internalEnvironmentsPromise = (async () => {
+    try {
+      const res = await fetch('/inbox-demo/api/env-urls');
+      if (res.ok) {
+        const data = (await res.json()) as { environments?: InternalEnvironment[] };
+        if (Array.isArray(data.environments)) {
+          internalEnvironments = data.environments;
+        }
+      }
+    } catch {
+      // Leave internalEnvironments empty on failure — only public envs remain available.
+    } finally {
+      internalEnvironmentsLoaded = true;
+    }
+  })();
+
+  return internalEnvironmentsPromise;
 };
 
 export const resolveApiEnvironment = (value: string | null): ApiEnvironment =>
@@ -61,10 +108,44 @@ export const resolveApiEnvironment = (value: string | null): ApiEnvironment =>
     ? (value as ApiEnvironment)
     : DEFAULT_API_ENVIRONMENT;
 
-export const getPresetApiUrls = (env: Exclude<ApiEnvironment, 'custom'>): CourierApiUrls => ({
-  courier: { ...API_ENVIRONMENT_PRESETS[env].courier },
-  inbox: { ...API_ENVIRONMENT_PRESETS[env].inbox },
-});
+/**
+ * The environments offered by the switcher: the public presets, any internal
+ * environments returned by the config endpoint, and Custom.
+ */
+export const getAvailableEnvironments = (): ApiEnvironmentOption[] => [
+  { id: 'production', label: PUBLIC_ENVIRONMENT_LABELS.production },
+  { id: 'production-eu', label: PUBLIC_ENVIRONMENT_LABELS['production-eu'] },
+  ...internalEnvironments.map((e) => ({ id: e.id as ApiEnvironment, label: e.label })),
+  { id: 'custom', label: 'Custom' },
+];
+
+/**
+ * Resolves the API URLs for a non-custom environment. Public environments come
+ * from {@link API_ENVIRONMENT_PRESETS}; internal ones come from the fetched
+ * config, falling back to production until the config loads (or if the env is
+ * not configured on the server).
+ */
+export const getPresetApiUrls = (env: Exclude<ApiEnvironment, 'custom'>): CourierApiUrls => {
+  if (isPublicEnvironment(env)) {
+    return {
+      courier: { ...API_ENVIRONMENT_PRESETS[env].courier },
+      inbox: { ...API_ENVIRONMENT_PRESETS[env].inbox },
+    };
+  }
+
+  const internal = findInternalEnvironment(env);
+  if (internal) {
+    return {
+      courier: { ...internal.apiUrls.courier },
+      inbox: { ...internal.apiUrls.inbox },
+    };
+  }
+
+  return {
+    courier: { ...API_ENVIRONMENT_PRESETS.production.courier },
+    inbox: { ...API_ENVIRONMENT_PRESETS.production.inbox },
+  };
+};
 
 export const areApiUrlsEqual = (left: CourierApiUrls, right: CourierApiUrls): boolean =>
   left.courier.rest === right.courier.rest &&

--- a/designer/app/lib/use-api-environments.ts
+++ b/designer/app/lib/use-api-environments.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { areInternalEnvironmentsLoaded, loadInternalEnvironments } from './api-urls';
+
+/**
+ * Loads the internal API environments from the config endpoint once, and
+ * triggers a re-render when they arrive. Returns whether the load has completed
+ * (public environments are always available regardless).
+ */
+export function useApiEnvironments(): boolean {
+  const [loaded, setLoaded] = useState<boolean>(areInternalEnvironmentsLoaded());
+
+  useEffect(() => {
+    if (loaded) return;
+    let active = true;
+    loadInternalEnvironments().then(() => {
+      if (active) setLoaded(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, [loaded]);
+
+  return loaded;
+}

--- a/designer/app/page.tsx
+++ b/designer/app/page.tsx
@@ -24,6 +24,7 @@ import {
   areApiUrlsEqual,
   getApiUrlsFromSearchParams
 } from "@/app/lib/api-urls";
+import { useApiEnvironments } from "@/app/lib/use-api-environments";
 import { themePresets, type ThemePreset } from '@/components/theme-presets';
 import { ExternalLink as ExternalLinkBase, FlaskConical as FlaskConicalBase, Send as SendBase, X as XBase } from 'lucide-react';
 
@@ -84,6 +85,10 @@ function HomeContent() {
   // Check if advanced mode is enabled
   const isAdvancedMode = searchParams.get('advanced') === 'true';
 
+  // Internal environment URLs (staging/dev/…) are served from the config
+  // endpoint, not this repo. Load them so a `?env=` deep link resolves correctly.
+  const environmentsLoaded = useApiEnvironments();
+
   const {
     apiEnvironment,
     presetApiUrls,
@@ -92,6 +97,14 @@ function HomeContent() {
 
   const hasCustomApiUrls = !areApiUrlsEqual(apiUrls, presetApiUrls);
   const shouldPassApiUrls = apiEnvironment !== DEFAULT_API_ENVIRONMENT || hasCustomApiUrls;
+
+  // A `?env=staging|dev` deep link needs the internal config before we sign in —
+  // otherwise we'd briefly connect to production. Public envs never wait.
+  const isInternalEnv =
+    apiEnvironment !== 'production' &&
+    apiEnvironment !== 'production-eu' &&
+    apiEnvironment !== 'custom';
+  const isEnvironmentPending = isInternalEnv && !environmentsLoaded;
 
   // Get courierRest for API calls
   const courierRest = apiUrls.courier.rest;
@@ -438,6 +451,11 @@ function HomeContent() {
       </header>
 
       {/* Main Content: Left and Right Panels */}
+      {isEnvironmentPending ? (
+        <div className="flex flex-1 items-center justify-center text-muted-foreground">
+          Loading environment…
+        </div>
+      ) : (
       <CourierAuth apiUrls={shouldPassApiUrls ? apiUrls : undefined} overrideUserId={overrideUserId} apiKey={overrideApiKey}>
         {({ userId, onClearUser }) => (
           <div className="flex flex-1 overflow-hidden">
@@ -509,6 +527,7 @@ function HomeContent() {
           </div>
         )}
       </CourierAuth>
+      )}
     </div>
   );
 }

--- a/designer/app/tests/page.tsx
+++ b/designer/app/tests/page.tsx
@@ -16,6 +16,7 @@ import {
   type TestsSharedFieldValues,
 } from '@/components/CourierTestsTab';
 import { getPresetApiUrls } from '@/app/lib/api-urls';
+import { useApiEnvironments } from '@/app/lib/use-api-environments';
 import {
   ArrowLeft as ArrowLeftBase,
   Loader2 as Loader2Base,
@@ -285,6 +286,10 @@ function TestsPageContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  // Load internal environment URLs (staging/dev/…) from the config endpoint so
+  // getPresetApiUrls resolves them; they're not stored in this public repo.
+  useApiEnvironments();
 
   const initialParsedRef = useRef<ReturnType<typeof parseTestsPageQuery> | null>(null);
   if (initialParsedRef.current === null) {

--- a/designer/components/AdvancedTab.tsx
+++ b/designer/components/AdvancedTab.tsx
@@ -6,9 +6,10 @@ import { type CourierApiUrls } from "@trycourier/courier-react";
 import {
   type ApiEnvironment,
   DEFAULT_API_ENVIRONMENT,
-  API_ENVIRONMENT_PRESETS,
+  getAvailableEnvironments,
   getPresetApiUrls,
 } from '@/app/lib/api-urls';
+import { useApiEnvironments } from '@/app/lib/use-api-environments';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -23,17 +24,13 @@ interface AdvancedTabProps {
   apiEnvironment: ApiEnvironment;
 }
 
-const ENVIRONMENT_LABELS: Record<ApiEnvironment, string> = {
-  production: 'Production',
-  'production-eu': 'Production EU',
-  staging: 'Staging',
-  dev: 'Dev',
-  custom: 'Custom',
-};
-
 export function AdvancedTab({ apiUrls, apiEnvironment }: AdvancedTabProps) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
+
+  // Load the internal environments so the switcher lists them (re-renders on arrival).
+  useApiEnvironments();
+  const environments = getAvailableEnvironments();
 
   const [selectedEnv, setSelectedEnv] = useState<ApiEnvironment>(apiEnvironment);
   const [courierRest, setCourierRest] = useState(apiUrls.courier.rest);
@@ -132,7 +129,7 @@ export function AdvancedTab({ apiUrls, apiEnvironment }: AdvancedTabProps) {
       setInboxGraphql(productionUrls.inbox.graphql);
       setInboxWebSocket(productionUrls.inbox.webSocket);
     } else {
-      const preset = API_ENVIRONMENT_PRESETS[nextEnv];
+      const preset = getPresetApiUrls(nextEnv);
       setCourierRest(preset.courier.rest);
       setCourierGraphql(preset.courier.graphql);
       setInboxGraphql(preset.inbox.graphql);
@@ -160,9 +157,9 @@ export function AdvancedTab({ apiUrls, apiEnvironment }: AdvancedTabProps) {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {(Object.keys(ENVIRONMENT_LABELS) as ApiEnvironment[]).map((env) => (
-                  <SelectItem key={env} value={env}>
-                    {ENVIRONMENT_LABELS[env]}
+                {environments.map((env) => (
+                  <SelectItem key={env.id} value={env.id}>
+                    {env.label}
                   </SelectItem>
                 ))}
               </SelectContent>


### PR DESCRIPTION
Makes the designer's environment switcher configurable per deployment instead of hard-coded.

## What changed
- **New route `GET /inbox-demo/api/env-urls`** — returns the additional environments a deployment wants to expose, read from an `INTERNAL_API_ENVIRONMENTS` env var (JSON array). Invalid/missing → empty list (no 500).
- **`api-urls.ts`** — keeps the built-in `production` / `production-eu` presets and merges in whatever the endpoint provides; `getAvailableEnvironments()` drives the switcher.
- **`use-api-environments.ts`** — client hook that loads the config once and re-renders on arrival.
- **`page.tsx`** — a `?env=` deep link waits for the config before signing in, so it never briefly targets the wrong environment.
- **`AdvancedTab.tsx`** — the env dropdown is driven by the merged list.
- **`tests/page.tsx`** — loads the config so its env selector resolves too.
- **`.env.example`** (+ `.gitignore` opt-in) documents the env vars.

## Result
Production works with zero config. Any additional environments are supplied per deployment via `INTERNAL_API_ENVIRONMENTS` (local `.env`, or the hosting env when deployed) rather than being baked into the app.

## Verified
- `GET /api/env-urls` returns the configured environments.
- The switcher lists them; selecting one resolves its URLs.
- `tsc --noEmit` clean; ESLint clean on all changed/added files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
