### PR TITLE
designer: runtime API config and send-form state fix

### DIFF
--- a/designer/.env.example
+++ b/designer/.env.example
@@ -1,0 +1,12 @@
+# Courier auth token used by the server routes (JWT issue + send).
+COURIER_AUTH_TOKEN=pk_prod_xxxxxxxxxxxxxxxxxxxxxxxx
+
+# Internal (non-public) API environments the inbox demo can target, returned by
+# GET /inbox-demo/api/env-urls. Kept OUT of this public repo — set here locally
+# and via the hosting platform's env (e.g. Vercel / GitHub secrets) when deployed.
+# Public production URLs are baked into the client and do NOT go here.
+#
+# JSON array; each entry: { id, label, apiUrls: { courier: { rest, graphql },
+# inbox: { graphql, webSocket } } }. Replace the example hosts below with the
+# real internal endpoints.
+INTERNAL_API_ENVIRONMENTS=[{"id":"staging","label":"Staging","apiUrls":{"courier":{"rest":"https://api.staging.example.com","graphql":"https://api.staging.example.com/client/q"},"inbox":{"graphql":"https://inbox.staging.example.com/q","webSocket":"wss://realtime.staging.example.com"}}},{"id":"dev","label":"Dev","apiUrls":{"courier":{"rest":"https://api.dev.example.com","graphql":"https://api.dev.example.com/client/q"},"inbox":{"graphql":"https://inbox.dev.example.com/q","webSocket":"wss://realtime.dev.example.com"}}}]

--- a/designer/.env.example
+++ b/designer/.env.example
@@ -1,4 +1,5 @@
-# Courier auth token used by the server routes (JWT issue + send).
+# Courier auth token used by the server routes (JWT issue + send) for the public
+# production environments. Internal environments use their own `authToken` below.
 COURIER_AUTH_TOKEN=pk_prod_xxxxxxxxxxxxxxxxxxxxxxxx
 
 # Internal (non-public) API environments the inbox demo can target, returned by
@@ -6,7 +7,12 @@ COURIER_AUTH_TOKEN=pk_prod_xxxxxxxxxxxxxxxxxxxxxxxx
 # and via the hosting platform's env (e.g. Vercel / GitHub secrets) when deployed.
 # Public production URLs are baked into the client and do NOT go here.
 #
-# JSON array; each entry: { id, label, apiUrls: { courier: { rest, graphql },
-# inbox: { graphql, webSocket } } }. Replace the example hosts below with the
-# real internal endpoints.
-INTERNAL_API_ENVIRONMENTS=[{"id":"staging","label":"Staging","apiUrls":{"courier":{"rest":"https://api.staging.example.com","graphql":"https://api.staging.example.com/client/q"},"inbox":{"graphql":"https://inbox.staging.example.com/q","webSocket":"wss://realtime.staging.example.com"}}},{"id":"dev","label":"Dev","apiUrls":{"courier":{"rest":"https://api.dev.example.com","graphql":"https://api.dev.example.com/client/q"},"inbox":{"graphql":"https://inbox.dev.example.com/q","webSocket":"wss://realtime.dev.example.com"}}}]
+# JSON array; each entry: { id, label, authToken, apiUrls: { courier: { rest,
+# graphql }, inbox: { graphql, webSocket } } }. Replace the example hosts below
+# with the real internal endpoints.
+#
+# `authToken` is the workspace key for that environment — a production key will
+# not authenticate against staging or dev, so each entry needs its own. It stays
+# server-side; /api/env-urls strips it before responding. Entries without one
+# fall back to COURIER_AUTH_TOKEN.
+INTERNAL_API_ENVIRONMENTS=[{"id":"staging","label":"Staging","authToken":"pk_staging_xxxxxxxxxxxxxxxxxxxxxxxx","apiUrls":{"courier":{"rest":"https://api.staging.example.com","graphql":"https://api.staging.example.com/client/q"},"inbox":{"graphql":"https://inbox.staging.example.com/q","webSocket":"wss://realtime.staging.example.com"}}},{"id":"dev","label":"Dev","authToken":"pk_dev_xxxxxxxxxxxxxxxxxxxxxxxx","apiUrls":{"courier":{"rest":"https://api.dev.example.com","graphql":"https://api.dev.example.com/client/q"},"inbox":{"graphql":"https://inbox.dev.example.com/q","webSocket":"wss://realtime.dev.example.com"}}}]

--- a/designer/.gitignore
+++ b/designer/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/designer/app/api/env-urls/route.ts
+++ b/designer/app/api/env-urls/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * Returns the internal (non-public) API environments the inbox demo can target.
+ *
+ * These are kept OUT of this public repo. They are read from the server
+ * `INTERNAL_API_ENVIRONMENTS` env var (a JSON array) — set locally via the
+ * designer `.env`, and via the hosting platform's env (e.g. Vercel / GitHub
+ * secrets) when deployed. Public production URLs stay hard-coded on the client.
+ *
+ * Env var shape:
+ *   INTERNAL_API_ENVIRONMENTS=[
+ *     {"id":"staging","label":"Staging","apiUrls":{
+ *        "courier":{"rest":"...","graphql":"..."},
+ *        "inbox":{"graphql":"...","webSocket":"..."}}},
+ *     ...
+ *   ]
+ */
+
+interface CourierApiUrls {
+  courier: { rest: string; graphql: string };
+  inbox: { graphql: string; webSocket: string };
+}
+
+interface EnvironmentOption {
+  id: string;
+  label: string;
+  apiUrls: CourierApiUrls;
+}
+
+function isValidApiUrls(value: unknown): value is CourierApiUrls {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  const courier = v.courier as Record<string, unknown> | undefined;
+  const inbox = v.inbox as Record<string, unknown> | undefined;
+  return (
+    !!courier &&
+    typeof courier.rest === 'string' &&
+    typeof courier.graphql === 'string' &&
+    !!inbox &&
+    typeof inbox.graphql === 'string' &&
+    typeof inbox.webSocket === 'string'
+  );
+}
+
+export async function GET() {
+  const raw = process.env.INTERNAL_API_ENVIRONMENTS;
+  let environments: EnvironmentOption[] = [];
+
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        environments = parsed
+          .filter(
+            (e): e is EnvironmentOption =>
+              e && typeof e.id === 'string' && isValidApiUrls(e.apiUrls)
+          )
+          .map((e) => ({
+            id: e.id,
+            label: typeof e.label === 'string' && e.label ? e.label : e.id,
+            apiUrls: e.apiUrls,
+          }));
+      }
+    } catch {
+      // Invalid JSON — return no internal environments rather than 500ing.
+    }
+  }
+
+  return NextResponse.json({ environments });
+}

--- a/designer/app/api/env-urls/route.ts
+++ b/designer/app/api/env-urls/route.ts
@@ -1,71 +1,21 @@
 import { NextResponse } from 'next/server';
+import { parseInternalEnvironments } from '@/app/api/lib/internal-environments';
 
 /**
- * Returns the internal (non-public) API environments the inbox demo can target.
- *
- * These are kept OUT of this public repo. They are read from the server
- * `INTERNAL_API_ENVIRONMENTS` env var (a JSON array) — set locally via the
- * designer `.env`, and via the hosting platform's env (e.g. Vercel / GitHub
- * secrets) when deployed. Public production URLs stay hard-coded on the client.
- *
- * Env var shape:
- *   INTERNAL_API_ENVIRONMENTS=[
- *     {"id":"staging","label":"Staging","apiUrls":{
- *        "courier":{"rest":"...","graphql":"..."},
- *        "inbox":{"graphql":"...","webSocket":"..."}}},
- *     ...
- *   ]
+ * Returns the internal (non-public) API environments the inbox demo can target,
+ * so the client can drive the env switcher without those hostnames living in
+ * this public repo. See `app/api/lib/internal-environments.ts` for the shape of
+ * the `INTERNAL_API_ENVIRONMENTS` env var this reads.
  */
-
-interface CourierApiUrls {
-  courier: { rest: string; graphql: string };
-  inbox: { graphql: string; webSocket: string };
-}
-
-interface EnvironmentOption {
-  id: string;
-  label: string;
-  apiUrls: CourierApiUrls;
-}
-
-function isValidApiUrls(value: unknown): value is CourierApiUrls {
-  if (!value || typeof value !== 'object') return false;
-  const v = value as Record<string, unknown>;
-  const courier = v.courier as Record<string, unknown> | undefined;
-  const inbox = v.inbox as Record<string, unknown> | undefined;
-  return (
-    !!courier &&
-    typeof courier.rest === 'string' &&
-    typeof courier.graphql === 'string' &&
-    !!inbox &&
-    typeof inbox.graphql === 'string' &&
-    typeof inbox.webSocket === 'string'
-  );
-}
-
 export async function GET() {
-  const raw = process.env.INTERNAL_API_ENVIRONMENTS;
-  let environments: EnvironmentOption[] = [];
-
-  if (raw) {
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
-        environments = parsed
-          .filter(
-            (e): e is EnvironmentOption =>
-              e && typeof e.id === 'string' && isValidApiUrls(e.apiUrls)
-          )
-          .map((e) => ({
-            id: e.id,
-            label: typeof e.label === 'string' && e.label ? e.label : e.id,
-            apiUrls: e.apiUrls,
-          }));
-      }
-    } catch {
-      // Invalid JSON — return no internal environments rather than 500ing.
-    }
-  }
+  // `authToken` is deliberately omitted: the client never needs a workspace
+  // credential. The server attaches the right one per environment when it
+  // handles /api/jwt and /api/messages.
+  const environments = parseInternalEnvironments().map(({ id, label, apiUrls }) => ({
+    id,
+    label,
+    apiUrls,
+  }));
 
   return NextResponse.json({ environments });
 }

--- a/designer/app/api/lib/courier.ts
+++ b/designer/app/api/lib/courier.ts
@@ -1,19 +1,16 @@
 import { Courier } from "@trycourier/courier";
+import { resolveApiKey } from "@/app/api/lib/internal-environments";
 
-let courierClient: Courier | null = null;
-
+/**
+ * Builds a Courier client for `baseUrl`.
+ *
+ * The credential is chosen per environment, not global: the env switcher points
+ * `baseUrl` at production/dev/staging, and each of those needs its own key. See
+ * {@link resolveApiKey}.
+ */
 export function getCourierClient(baseUrl: string, apiKey?: string) {
-
-  const key = apiKey || process.env.COURIER_AUTH_TOKEN;
-  if (!key) {
-    throw new Error("COURIER_AUTH_TOKEN environment variable is not set");
-  }
-
-  courierClient = new Courier({
-    apiKey: key,
+  return new Courier({
+    apiKey: resolveApiKey(baseUrl, apiKey),
     baseURL: baseUrl,
   });
-
-  return courierClient;
 }
-

--- a/designer/app/api/lib/internal-environments.ts
+++ b/designer/app/api/lib/internal-environments.ts
@@ -1,0 +1,143 @@
+/**
+ * Server-side view of the API environments the inbox demo can target, and the
+ * credential that belongs to each one.
+ *
+ * The internal (non-public) environments are read from the server
+ * `INTERNAL_API_ENVIRONMENTS` env var — set locally via the designer `.env`, and
+ * via the hosting platform's env when deployed — so their hostnames and tokens
+ * never land in this public repo.
+ *
+ * Env var shape (`authToken` optional; omit it to use `COURIER_AUTH_TOKEN`):
+ *   INTERNAL_API_ENVIRONMENTS=[
+ *     {"id":"staging","label":"Staging","authToken":"pk_…","apiUrls":{
+ *        "courier":{"rest":"...","graphql":"..."},
+ *        "inbox":{"graphql":"...","webSocket":"..."}}},
+ *     ...
+ *   ]
+ *
+ * This module must stay server-only: it reads auth tokens. The `/api/env-urls`
+ * route deliberately strips `authToken` before responding.
+ */
+
+export interface EnvironmentApiUrls {
+  courier: { rest: string; graphql: string };
+  inbox: { graphql: string; webSocket: string };
+}
+
+export interface InternalEnvironment {
+  id: string;
+  label: string;
+  apiUrls: EnvironmentApiUrls;
+  /** Credential for this environment. Never sent to the client. */
+  authToken?: string;
+}
+
+/**
+ * REST bases for the public environments, whose credential is the default
+ * `COURIER_AUTH_TOKEN`. Mirrors `API_ENVIRONMENT_PRESETS` in
+ * `app/lib/api-urls.ts`, which is the client-side source of truth — duplicated
+ * rather than imported so a server route never pulls in the client module.
+ */
+const PUBLIC_COURIER_REST_URLS = [
+  'https://api.courier.com',
+  'https://api.eu.courier.com',
+];
+
+function isValidApiUrls(value: unknown): value is EnvironmentApiUrls {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  const courier = v.courier as Record<string, unknown> | undefined;
+  const inbox = v.inbox as Record<string, unknown> | undefined;
+  return (
+    !!courier &&
+    typeof courier.rest === 'string' &&
+    typeof courier.graphql === 'string' &&
+    !!inbox &&
+    typeof inbox.graphql === 'string' &&
+    typeof inbox.webSocket === 'string'
+  );
+}
+
+/**
+ * Parses `INTERNAL_API_ENVIRONMENTS`, dropping malformed entries.
+ *
+ * Deliberately not cached: this is a handful of bytes of JSON per request, and a
+ * cache would serve a stale list after the env changes.
+ */
+export function parseInternalEnvironments(): InternalEnvironment[] {
+  const raw = process.env.INTERNAL_API_ENVIRONMENTS;
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Invalid JSON — behave as if no internal environments were configured
+    // rather than failing every request.
+    return [];
+  }
+
+  if (!Array.isArray(parsed)) return [];
+
+  return parsed
+    .filter(
+      (e): e is InternalEnvironment =>
+        e && typeof e.id === 'string' && isValidApiUrls(e.apiUrls)
+    )
+    .map((e) => ({
+      id: e.id,
+      label: typeof e.label === 'string' && e.label ? e.label : e.id,
+      apiUrls: e.apiUrls,
+      authToken: typeof e.authToken === 'string' ? e.authToken.trim() : undefined,
+    }));
+}
+
+const normalizeBase = (url: string): string =>
+  url.trim().replace(/\/+$/, '').toLowerCase();
+
+/**
+ * Picks the credential to use for a request against `courierRest`.
+ *
+ * An explicit `apiKey` from the caller always wins — that's the `?apiKey=`
+ * override, and it's how the Custom environment reaches an arbitrary host.
+ *
+ * Otherwise the server is about to spend one of *its own* credentials, so
+ * `courierRest` must be an environment we recognize. Refusing unknown hosts
+ * keeps this route from being used to send `COURIER_AUTH_TOKEN` somewhere it
+ * doesn't belong — the designer is deployed publicly, so these routes take
+ * their target URL from untrusted input.
+ */
+export function resolveApiKey(courierRest: string | undefined, apiKey?: string): string {
+  if (apiKey) {
+    return apiKey;
+  }
+
+  const base = normalizeBase(courierRest || PUBLIC_COURIER_REST_URLS[0]);
+
+  if (PUBLIC_COURIER_REST_URLS.some((url) => normalizeBase(url) === base)) {
+    const token = process.env.COURIER_AUTH_TOKEN;
+    if (!token) {
+      throw new Error('COURIER_AUTH_TOKEN environment variable is not set');
+    }
+    return token;
+  }
+
+  const environment = parseInternalEnvironments().find(
+    (e) => normalizeBase(e.apiUrls.courier.rest) === base
+  );
+
+  if (!environment) {
+    throw new Error(
+      `Unrecognized API URL "${courierRest}". Pass an explicit apiKey to use a custom environment.`
+    );
+  }
+
+  if (!environment.authToken) {
+    throw new Error(
+      `No auth token configured for the "${environment.label}" environment. ` +
+        `Add an "authToken" to its INTERNAL_API_ENVIRONMENTS entry, or pass an explicit apiKey.`
+    );
+  }
+
+  return environment.authToken;
+}

--- a/designer/app/lib/api-urls.ts
+++ b/designer/app/lib/api-urls.ts
@@ -5,12 +5,22 @@ type SearchParamsLike = {
 };
 
 export type ApiEnvironment = 'production' | 'production-eu' | 'staging' | 'dev' | 'custom';
+type PublicApiEnvironment = 'production' | 'production-eu';
 
 export const DEFAULT_API_ENVIRONMENT: ApiEnvironment = 'production';
 
 const VALID_ENVIRONMENTS: ApiEnvironment[] = ['production', 'production-eu', 'staging', 'dev', 'custom'];
 
-export const API_ENVIRONMENT_PRESETS: Record<Exclude<ApiEnvironment, 'custom'>, Readonly<CourierApiUrls>> = {
+/**
+ * Public, world-shippable environments — these URLs are already published in the
+ * SDK and docs, so it's fine to keep them in this public repo.
+ *
+ * Internal environments (staging/dev/…) are intentionally NOT stored here. They
+ * are served at runtime by `GET /inbox-demo/api/env-urls` from server env vars
+ * (see {@link loadInternalEnvironments}) so internal hostnames never land in
+ * this public repo.
+ */
+export const API_ENVIRONMENT_PRESETS: Record<PublicApiEnvironment, Readonly<CourierApiUrls>> = {
   production: {
     courier: {
       rest: 'https://api.courier.com',
@@ -31,29 +41,66 @@ export const API_ENVIRONMENT_PRESETS: Record<Exclude<ApiEnvironment, 'custom'>, 
       webSocket: 'wss://realtime.eu.courier.io',
     },
   },
-  staging: {
-    courier: {
-      rest: 'https://api.staging-trycourier.com',
-      graphql: 'https://yubmnstah4.execute-api.us-east-1.amazonaws.com/staging/client/q',
-    },
-    inbox: {
-      graphql: 'https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q',
-      // Cloudflare-fronted realtime vanity (TLS), mirrors prod's realtime.courier.io.
-      // The raw `inbox-staging-ws-alb-*.elb.amazonaws.com` ELB has no browser-valid
-      // TLS cert and 301-redirects on http, so a browser WebSocket can't connect to it.
-      webSocket: 'wss://realtime.courierstaging.com',
-    },
-  },
-  dev: {
-    courier: {
-      rest: 'https://api.courierdev.com',
-      graphql: 'https://api.courierdev.com/client/q',
-    },
-    inbox: {
-      graphql: 'https://inbox.courierdev.com/q',
-      webSocket: 'wss://9mrugsdnk1.execute-api.us-east-1.amazonaws.com/dev',
-    },
-  },
+};
+
+const PUBLIC_ENVIRONMENT_LABELS: Record<PublicApiEnvironment, string> = {
+  production: 'Production',
+  'production-eu': 'Production EU',
+};
+
+export interface ApiEnvironmentOption {
+  id: ApiEnvironment;
+  label: string;
+}
+
+const isPublicEnvironment = (env: string): env is PublicApiEnvironment =>
+  env === 'production' || env === 'production-eu';
+
+// --- Internal environments, fetched at runtime from the config endpoint -------
+
+interface InternalEnvironment {
+  id: string;
+  label: string;
+  apiUrls: CourierApiUrls;
+}
+
+let internalEnvironments: InternalEnvironment[] = [];
+let internalEnvironmentsLoaded = false;
+let internalEnvironmentsPromise: Promise<void> | null = null;
+
+const findInternalEnvironment = (env: string): InternalEnvironment | undefined =>
+  internalEnvironments.find((e) => e.id === env);
+
+/** True once the internal environment list has been fetched (or has failed) at least once. */
+export const areInternalEnvironmentsLoaded = (): boolean => internalEnvironmentsLoaded;
+
+/**
+ * Fetches the internal (non-public) API environments from the server config
+ * endpoint and caches them. Public prod/prod-eu URLs are baked into this file;
+ * everything else is served from server env so it never lands in this public
+ * repo. Runs at most once — safe to call repeatedly.
+ */
+export const loadInternalEnvironments = (): Promise<void> => {
+  if (internalEnvironmentsLoaded) return Promise.resolve();
+  if (internalEnvironmentsPromise) return internalEnvironmentsPromise;
+
+  internalEnvironmentsPromise = (async () => {
+    try {
+      const res = await fetch('/inbox-demo/api/env-urls');
+      if (res.ok) {
+        const data = (await res.json()) as { environments?: InternalEnvironment[] };
+        if (Array.isArray(data.environments)) {
+          internalEnvironments = data.environments;
+        }
+      }
+    } catch {
+      // Leave internalEnvironments empty on failure — only public envs remain available.
+    } finally {
+      internalEnvironmentsLoaded = true;
+    }
+  })();
+
+  return internalEnvironmentsPromise;
 };
 
 export const resolveApiEnvironment = (value: string | null): ApiEnvironment =>
@@ -61,10 +108,44 @@ export const resolveApiEnvironment = (value: string | null): ApiEnvironment =>
     ? (value as ApiEnvironment)
     : DEFAULT_API_ENVIRONMENT;
 
-export const getPresetApiUrls = (env: Exclude<ApiEnvironment, 'custom'>): CourierApiUrls => ({
-  courier: { ...API_ENVIRONMENT_PRESETS[env].courier },
-  inbox: { ...API_ENVIRONMENT_PRESETS[env].inbox },
-});
+/**
+ * The environments offered by the switcher: the public presets, any internal
+ * environments returned by the config endpoint, and Custom.
+ */
+export const getAvailableEnvironments = (): ApiEnvironmentOption[] => [
+  { id: 'production', label: PUBLIC_ENVIRONMENT_LABELS.production },
+  { id: 'production-eu', label: PUBLIC_ENVIRONMENT_LABELS['production-eu'] },
+  ...internalEnvironments.map((e) => ({ id: e.id as ApiEnvironment, label: e.label })),
+  { id: 'custom', label: 'Custom' },
+];
+
+/**
+ * Resolves the API URLs for a non-custom environment. Public environments come
+ * from {@link API_ENVIRONMENT_PRESETS}; internal ones come from the fetched
+ * config, falling back to production until the config loads (or if the env is
+ * not configured on the server).
+ */
+export const getPresetApiUrls = (env: Exclude<ApiEnvironment, 'custom'>): CourierApiUrls => {
+  if (isPublicEnvironment(env)) {
+    return {
+      courier: { ...API_ENVIRONMENT_PRESETS[env].courier },
+      inbox: { ...API_ENVIRONMENT_PRESETS[env].inbox },
+    };
+  }
+
+  const internal = findInternalEnvironment(env);
+  if (internal) {
+    return {
+      courier: { ...internal.apiUrls.courier },
+      inbox: { ...internal.apiUrls.inbox },
+    };
+  }
+
+  return {
+    courier: { ...API_ENVIRONMENT_PRESETS.production.courier },
+    inbox: { ...API_ENVIRONMENT_PRESETS.production.inbox },
+  };
+};
 
 export const areApiUrlsEqual = (left: CourierApiUrls, right: CourierApiUrls): boolean =>
   left.courier.rest === right.courier.rest &&

--- a/designer/app/lib/use-api-environments.ts
+++ b/designer/app/lib/use-api-environments.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { areInternalEnvironmentsLoaded, loadInternalEnvironments } from './api-urls';
+
+/**
+ * Loads the internal API environments from the config endpoint once, and
+ * triggers a re-render when they arrive. Returns whether the load has completed
+ * (public environments are always available regardless).
+ */
+export function useApiEnvironments(): boolean {
+  const [loaded, setLoaded] = useState<boolean>(areInternalEnvironmentsLoaded());
+
+  useEffect(() => {
+    if (loaded) return;
+    let active = true;
+    loadInternalEnvironments().then(() => {
+      if (active) setLoaded(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, [loaded]);
+
+  return loaded;
+}

--- a/designer/app/page.tsx
+++ b/designer/app/page.tsx
@@ -24,6 +24,7 @@ import {
   areApiUrlsEqual,
   getApiUrlsFromSearchParams
 } from "@/app/lib/api-urls";
+import { useApiEnvironments } from "@/app/lib/use-api-environments";
 import { themePresets, type ThemePreset } from '@/components/theme-presets';
 import { ExternalLink as ExternalLinkBase, FlaskConical as FlaskConicalBase, Send as SendBase, X as XBase } from 'lucide-react';
 
@@ -84,6 +85,10 @@ function HomeContent() {
   // Check if advanced mode is enabled
   const isAdvancedMode = searchParams.get('advanced') === 'true';
 
+  // Internal environment URLs (staging/dev/…) are served from the config
+  // endpoint, not this repo. Load them so a `?env=` deep link resolves correctly.
+  const environmentsLoaded = useApiEnvironments();
+
   const {
     apiEnvironment,
     presetApiUrls,
@@ -92,6 +97,14 @@ function HomeContent() {
 
   const hasCustomApiUrls = !areApiUrlsEqual(apiUrls, presetApiUrls);
   const shouldPassApiUrls = apiEnvironment !== DEFAULT_API_ENVIRONMENT || hasCustomApiUrls;
+
+  // A `?env=staging|dev` deep link needs the internal config before we sign in —
+  // otherwise we'd briefly connect to production. Public envs never wait.
+  const isInternalEnv =
+    apiEnvironment !== 'production' &&
+    apiEnvironment !== 'production-eu' &&
+    apiEnvironment !== 'custom';
+  const isEnvironmentPending = isInternalEnv && !environmentsLoaded;
 
   // Get courierRest for API calls
   const courierRest = apiUrls.courier.rest;
@@ -438,6 +451,11 @@ function HomeContent() {
       </header>
 
       {/* Main Content: Left and Right Panels */}
+      {isEnvironmentPending ? (
+        <div className="flex flex-1 items-center justify-center text-muted-foreground">
+          Loading environment…
+        </div>
+      ) : (
       <CourierAuth apiUrls={shouldPassApiUrls ? apiUrls : undefined} overrideUserId={overrideUserId} apiKey={overrideApiKey}>
         {({ userId, onClearUser }) => (
           <div className="flex flex-1 overflow-hidden">
@@ -509,6 +527,7 @@ function HomeContent() {
           </div>
         )}
       </CourierAuth>
+      )}
     </div>
   );
 }

--- a/designer/app/page.tsx
+++ b/designer/app/page.tsx
@@ -125,6 +125,11 @@ function HomeContent() {
   // Helper to update URL params
   const updateUrlParams = useCallback((key: string, value: string, defaultValue: string) => {
     const params = new URLSearchParams(searchParams.toString());
+    // Nothing to write — skip the navigation so we don't re-render the page for
+    // a URL that is already correct.
+    if ((params.get(key) ?? defaultValue) === value) {
+      return;
+    }
     if (value === defaultValue) {
       params.delete(key);
     } else {
@@ -242,8 +247,13 @@ function HomeContent() {
     setIsResizing(true);
   };
 
-  // Left Panel Content Component (reusable for desktop and mobile)
-  const LeftPanelContent = ({ userId, onClearUser, onTabChange, courierRest }: { userId: string; onClearUser: () => void; onTabChange?: () => void; courierRest?: string }) => (
+  // Left panel content (reusable for desktop and mobile).
+  //
+  // This is a render *function*, not a component: a component declared inside
+  // `HomeContent` gets a new identity on every render, which makes React
+  // unmount and remount the whole left panel (losing the send form's state)
+  // any time this page re-renders — on a URL param update, a panel resize, etc.
+  const renderLeftPanel = ({ userId, onClearUser, onTabChange, courierRest }: { userId: string; onClearUser: () => void; onTabChange?: () => void; courierRest?: string }) => (
     <Tabs
       value={activeLeftTab}
       onValueChange={(tabId: string) => {
@@ -395,11 +405,7 @@ function HomeContent() {
                 >
                   {({ userId, onClearUser }) => (
                     <div className="flex-1 flex flex-col min-h-0 overflow-hidden pt-16">
-                      <LeftPanelContent
-                        userId={userId}
-                        onClearUser={onClearUser}
-                        courierRest={courierRest}
-                      />
+                      {renderLeftPanel({ userId, onClearUser, courierRest })}
                     </div>
                   )}
                 </CourierAuth>
@@ -464,7 +470,7 @@ function HomeContent() {
               className="hidden lg:block border-r border-border flex-shrink-0 bg-background"
               style={{ width: `${leftPanelWidth}px`, minWidth: `${initialWidth}px` }}
             >
-              <LeftPanelContent userId={userId} onClearUser={onClearUser} onTabChange={undefined} courierRest={courierRest} />
+              {renderLeftPanel({ userId, onClearUser, onTabChange: undefined, courierRest })}
             </div>
 
             {/* Resize Handle - Hidden on mobile */}

--- a/designer/app/tests/page.tsx
+++ b/designer/app/tests/page.tsx
@@ -16,6 +16,7 @@ import {
   type TestsSharedFieldValues,
 } from '@/components/CourierTestsTab';
 import { getPresetApiUrls } from '@/app/lib/api-urls';
+import { useApiEnvironments } from '@/app/lib/use-api-environments';
 import {
   ArrowLeft as ArrowLeftBase,
   Loader2 as Loader2Base,
@@ -285,6 +286,10 @@ function TestsPageContent() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  // Load internal environment URLs (staging/dev/…) from the config endpoint so
+  // getPresetApiUrls resolves them; they're not stored in this public repo.
+  useApiEnvironments();
 
   const initialParsedRef = useRef<ReturnType<typeof parseTestsPageQuery> | null>(null);
   if (initialParsedRef.current === null) {

--- a/designer/components/AdvancedTab.tsx
+++ b/designer/components/AdvancedTab.tsx
@@ -6,9 +6,10 @@ import { type CourierApiUrls } from "@trycourier/courier-react";
 import {
   type ApiEnvironment,
   DEFAULT_API_ENVIRONMENT,
-  API_ENVIRONMENT_PRESETS,
+  getAvailableEnvironments,
   getPresetApiUrls,
 } from '@/app/lib/api-urls';
+import { useApiEnvironments } from '@/app/lib/use-api-environments';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -23,17 +24,13 @@ interface AdvancedTabProps {
   apiEnvironment: ApiEnvironment;
 }
 
-const ENVIRONMENT_LABELS: Record<ApiEnvironment, string> = {
-  production: 'Production',
-  'production-eu': 'Production EU',
-  staging: 'Staging',
-  dev: 'Dev',
-  custom: 'Custom',
-};
-
 export function AdvancedTab({ apiUrls, apiEnvironment }: AdvancedTabProps) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
+
+  // Load the internal environments so the switcher lists them (re-renders on arrival).
+  useApiEnvironments();
+  const environments = getAvailableEnvironments();
 
   const [selectedEnv, setSelectedEnv] = useState<ApiEnvironment>(apiEnvironment);
   const [courierRest, setCourierRest] = useState(apiUrls.courier.rest);
@@ -132,7 +129,7 @@ export function AdvancedTab({ apiUrls, apiEnvironment }: AdvancedTabProps) {
       setInboxGraphql(productionUrls.inbox.graphql);
       setInboxWebSocket(productionUrls.inbox.webSocket);
     } else {
-      const preset = API_ENVIRONMENT_PRESETS[nextEnv];
+      const preset = getPresetApiUrls(nextEnv);
       setCourierRest(preset.courier.rest);
       setCourierGraphql(preset.courier.graphql);
       setInboxGraphql(preset.inbox.graphql);
@@ -160,9 +157,9 @@ export function AdvancedTab({ apiUrls, apiEnvironment }: AdvancedTabProps) {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {(Object.keys(ENVIRONMENT_LABELS) as ApiEnvironment[]).map((env) => (
-                  <SelectItem key={env} value={env}>
-                    {ENVIRONMENT_LABELS[env]}
+                {environments.map((env) => (
+                  <SelectItem key={env.id} value={env.id}>
+                    {env.label}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/designer/components/SendMessageForm.tsx
+++ b/designer/components/SendMessageForm.tsx
@@ -201,7 +201,8 @@ export function SendMessageForm({
       });
       setTitle('');
       setBody('');
-      changeTemplateId('');
+      // The template id is a persistent selection (and part of the shareable
+      // URL), so it survives a send — you usually want to send it again.
       setTags('');
       setActions([]);
       setVariables([]);


### PR DESCRIPTION
Three changes to the internal designer app.

**Runtime API config.** The environment list is read at runtime from server env via `GET /inbox-demo/api/env-urls` rather than hard-coded, so those URLs stay out of this repo. Public production presets remain in the client. Re-applies a change that was previously reverted.

**Per-environment credentials.** `/api/jwt` and `/api/messages` paired whichever API base was selected with a single shared token, so anything other than the default failed to authenticate — the SDK never signed in and the inbox socket never opened. The credential is now resolved per environment, server-side; `/api/env-urls` still strips tokens before responding. The requested API base is also restricted to environments we recognize, so the server only spends its own credential against known hosts (callers passing their own `apiKey` are unaffected, which is how the Custom environment works).

**Send-form state.** The left panel was a component declared inside the page, so it got a new identity on every render and React remounted the subtree — clearing anything typed into the send form — on any URL param update or panel resize. It's now a render function. Also skips the router update when a param already holds its target value, and keeps the template id after a send since it's part of the shareable URL.

## Verification

- `tsc --noEmit` and eslint clean on the touched files
- Token issuance verified per environment through the app's own routes; unknown bases refused
- End-to-end through the app: token issued, socket connected, message sent via `/api/messages`, delivery confirmed on the socket
- No credentials in the `/api/env-urls` response

No changeset — `designer` is private and not published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)