### PR TITLE
feat(inbox): connect on iwpv=v2 and track socket-delivered clicks

### DIFF
--- a/.changeset/inbox-socket-iwpv2-canonical-message.md
+++ b/.changeset/inbox-socket-iwpv2-canonical-message.md
@@ -1,0 +1,17 @@
+---
+"@trycourier/courier-js": minor
+"@trycourier/courier-ui-inbox": minor
+---
+
+Inbox: connect on the `iwpv=v2` wire protocol, which publishes the canonical message — the same object the GraphQL read returns, with `trackingIds` at the root and no nested `data.trackingIds` duplicate.
+
+This fixes click, read and archive tracking for messages that arrive over the socket. Previously the socket left `trackingIds` nested under `data` while GraphQL returned them at the root; this SDK reads only the root, so clicking a live-delivered message tracked **nothing**, silently, while clicking the same message after a refresh worked.
+
+Two related gaps are fixed alongside it:
+
+- `CourierInboxDatastore.clickMessage` returned in total silence when `clickTrackingId` was absent, which made a wire-shape problem indistinguishable from a successful no-op. It now logs.
+- Action-button clicks were never tracked at all under any protocol version (`onMessageActionClick` carried a standing `// TODO: Track action click?`). New `CourierInboxDatastore.clickMessageAction` records them using the per-action `action.data.trackingId`, which identifies *which* button was pressed.
+
+`InboxMessage` gains the remaining canonical fields: `icon`, `pinned`, `userId`, `content` (`html`/`elemental`), and `brandId` / `trackingUrl`, which are promoted out of `data` to match how the message is indexed and returned by GraphQL. `trackingIds` also gains `channelTrackingId`.
+
+Requires the `iwpv=v2` server support to be deployed first — the server downgrades an unrecognized version to the legacy protocol without erroring.

--- a/@trycourier/courier-js/src/__tests__/courier-socket.test.ts
+++ b/@trycourier/courier-js/src/__tests__/courier-socket.test.ts
@@ -1,5 +1,6 @@
 import { CourierClientOptions } from "../client/courier-client";
 import { CourierSocket } from "../socket/courier-socket";
+import { INBOX_WIRE_PROTOCOL_VERSION } from "../socket/version";
 import { CourierApiUrls } from "../types/courier-api-urls";
 import { ServerMessage, ServerResponse } from "../types/socket/protocol/messages";
 import { CourierUserAgent } from "../utils/courier-user-agent";
@@ -115,7 +116,12 @@ describe('CourierSocket', () => {
       const url = new URL(capturedUrl);
       expect(url.searchParams.get('auth')).toBe(OPTIONS.accessToken);
       expect(url.searchParams.get('cid')).toBe(OPTIONS.connectionId);
-      expect(url.searchParams.get('iwpv')).toBe('v1');
+      // v2 is the canonical payload: trackingIds at the root, no nested duplicate.
+      // Pinned deliberately — the server downgrades an unknown version to the
+      // legacy protocol without erroring, so a wrong value here is a silent
+      // regression in tracking rather than a visible failure.
+      expect(url.searchParams.get('iwpv')).toBe(INBOX_WIRE_PROTOCOL_VERSION);
+      expect(INBOX_WIRE_PROTOCOL_VERSION).toBe('v2');
       expect(url.searchParams.get('userId')).toBe(OPTIONS.userId);
       expect(url.searchParams.get('sdk')).toBe(USER_AGENT_CLIENT_NAME);
       expect(url.searchParams.get('sdkv')).toBe(USER_AGENT_CLIENT_VERSION);

--- a/@trycourier/courier-js/src/socket/version.ts
+++ b/@trycourier/courier-js/src/socket/version.ts
@@ -1,1 +1,17 @@
-export const INBOX_WIRE_PROTOCOL_VERSION = 'v1';
+/**
+ * Inbox wire protocol version negotiated per socket connection via `?iwpv=`.
+ *
+ * `v2` publishes the canonical message: the same object the GraphQL read returns,
+ * with `trackingIds` at the root and no nested `data.trackingIds` duplicate. On
+ * `v1` the socket left `trackingIds` nested under `data` while GraphQL returned
+ * them at the root, so this SDK — which reads only the root — silently tracked
+ * nothing for a message that arrived over the socket, while the same message
+ * tracked fine after a refetch.
+ *
+ * The server downgrades an unrecognized version to the legacy protocol rather
+ * than rejecting the connection, so this must not be raised ahead of the server
+ * supporting it: a client asking for a version the server does not know gets the
+ * legacy shape and no error. v2 frames carry `iwpv: "v2"` so a downgrade is
+ * detectable rather than silent.
+ */
+export const INBOX_WIRE_PROTOCOL_VERSION = 'v2';

--- a/@trycourier/courier-js/src/types/inbox.ts
+++ b/@trycourier/courier-js/src/types/inbox.ts
@@ -45,6 +45,37 @@ export interface InboxAction {
   style?: string;
 }
 
+/** Tracking ids for a message. Always at the root of the message — see below. */
+export interface InboxMessageTrackingIds {
+  archiveTrackingId?: string;
+  channelTrackingId?: string;
+  clickTrackingId?: string;
+  deliverTrackingId?: string;
+  openTrackingId?: string;
+  readTrackingId?: string;
+  unreadTrackingId?: string;
+}
+
+/**
+ * Rendered message body.
+ *
+ * Mirrors the GraphQL `FullMessage.content` field. Delivered over the socket on
+ * `iwpv=v2`; the GraphQL list query does not return it.
+ */
+export interface InboxMessageContent {
+  html?: string;
+  elemental?: unknown[];
+}
+
+/**
+ * A single inbox message.
+ *
+ * One shape regardless of how it arrived. A message delivered live over the
+ * socket and the same message fetched from GraphQL used to disagree — most
+ * visibly `trackingIds`, which the socket nested under `data` while GraphQL
+ * returned it at the root. `iwpv=v2` removes that divergence, so `trackingIds` is
+ * read from the root and nowhere else.
+ */
 export interface InboxMessage {
   messageId: string;
   /** The account / sub-tenant this message is scoped to, if any. */
@@ -53,20 +84,32 @@ export interface InboxMessage {
   body?: string;
   preview?: string;
   actions?: InboxAction[];
+  /**
+   * Arbitrary key/value data sent with the message.
+   *
+   * Does **not** contain `trackingIds`, `brandId` or `trackingUrl` — those are
+   * promoted to the root, matching how the message is indexed and returned by
+   * GraphQL.
+   */
   data?: Record<string, any>;
   created?: string;
   archived?: string;
   read?: string;
   opened?: string;
   tags?: string[];
-  trackingIds?: {
-    archiveTrackingId?: string;
-    openTrackingId?: string;
-    clickTrackingId?: string;
-    deliverTrackingId?: string;
-    unreadTrackingId?: string;
-    readTrackingId?: string;
-  };
+  /** URL of the message icon, if the brand or message specifies one. */
+  icon?: string;
+  /** Present only when the message is pinned to a slot. */
+  pinned?: { slotId?: string };
+  /** The user this message belongs to. */
+  userId?: string;
+  trackingIds?: InboxMessageTrackingIds;
+  /** Rendered body. Socket-delivered messages only. */
+  content?: InboxMessageContent;
+  /** Brand that rendered this message. Promoted out of `data`. */
+  brandId?: string;
+  /** Channel tracking URL for this message. Promoted out of `data`. */
+  trackingUrl?: string;
 }
 
 export interface CourierGetInboxMessageResponse {

--- a/@trycourier/courier-ui-inbox/src/components/courier-inbox.ts
+++ b/@trycourier/courier-ui-inbox/src/components/courier-inbox.ts
@@ -386,8 +386,10 @@ export class CourierInbox extends CourierBaseElement {
         this._onMessageClick?.({ message, index });
       },
       onMessageActionClick: (message, action, index) => {
-
-        // TODO: Track action click?
+        // Action clicks were never recorded under any protocol version. Tracks on
+        // the per-action id (action.data.trackingId), which identifies which button
+        // was pressed — distinct from the message-level clickTrackingId used above.
+        CourierInboxDatastore.shared.clickMessageAction({ message, action });
 
         this.dispatchEvent(new CustomEvent('message-action-click', {
           detail: { message, action, index },

--- a/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
@@ -13,8 +13,11 @@ const mockOpen = jest.fn();
 const mockBatchOpen = jest.fn();
 const mockRead = jest.fn();
 const mockUnread = jest.fn();
+const mockClick = jest.fn();
 const mockAddMessageEventListener = jest.fn();
 const mockConnect = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerError = jest.fn();
 
 // Create mock CourierInboxSocket with mutable properties
 const mockSocket = {
@@ -39,14 +42,15 @@ jest.mock("@trycourier/courier-js", () => ({
           batchOpen: (ids: string[]) => mockBatchOpen(ids),
           read: () => mockRead(),
           unread: () => mockUnread(),
+          click: (props: { messageId: string; trackingId: string }) => mockClick(props),
           get socket() {
             return mockSocket;
           },
         },
         options: {
           logger: {
-            error: jest.fn(),
-            info: jest.fn(),
+            error: (...args: unknown[]) => mockLoggerError(...args),
+            info: (...args: unknown[]) => mockLoggerInfo(...args),
             warn: jest.fn(),
           },
           userId: "123",
@@ -745,6 +749,94 @@ describe("CourierInboxDatastore", () => {
       // Verify onError was called
       expect(onErrorMock).toHaveBeenCalledTimes(1);
       expect(onErrorMock).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  /**
+   * Click tracking reads `trackingIds` from the root of the message. Under iwpv=v1
+   * the socket nested them under `data`, so a socket-delivered message tracked
+   * nothing here while the same message tracked fine after a refetch. iwpv=v2
+   * removes that split; these cover the read sites that depend on it.
+   */
+  describe("click tracking", () => {
+    it("tracks a message click using the root-level clickTrackingId", async () => {
+      const message: InboxMessage = {
+        ...getMessage(),
+        trackingIds: { clickTrackingId: "click-1" },
+      };
+
+      await CourierInboxDatastore.shared.clickMessage({ message });
+
+      expect(mockClick).toHaveBeenCalledTimes(1);
+      expect(mockClick).toHaveBeenCalledWith({
+        messageId: message.messageId,
+        trackingId: "click-1",
+      });
+    });
+
+    // Regression: a missing id used to return in total silence, which made a wire
+    // shape problem indistinguishable from a successful no-op.
+    it("logs instead of silently skipping when clickTrackingId is absent", async () => {
+      const message = getMessage();
+
+      await CourierInboxDatastore.shared.clickMessage({ message });
+
+      expect(mockClick).not.toHaveBeenCalled();
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining("no clickTrackingId")
+      );
+    });
+
+    it("ignores a nested data.trackingIds copy, which v2 does not send", async () => {
+      const message: InboxMessage = {
+        ...getMessage(),
+        data: { trackingIds: { clickTrackingId: "nested-should-be-ignored" } },
+      };
+
+      await CourierInboxDatastore.shared.clickMessage({ message });
+
+      expect(mockClick).not.toHaveBeenCalled();
+    });
+
+    // Action clicks were never tracked at all, under any protocol version.
+    it("tracks an action click using the per-action trackingId", async () => {
+      const message = getMessage();
+      const action = { content: "Open", href: "https://x", data: { trackingId: "action-1" } };
+
+      await CourierInboxDatastore.shared.clickMessageAction({ message, action });
+
+      expect(mockClick).toHaveBeenCalledTimes(1);
+      expect(mockClick).toHaveBeenCalledWith({
+        messageId: message.messageId,
+        trackingId: "action-1",
+      });
+    });
+
+    it("logs when an action carries no trackingId", async () => {
+      const message = getMessage();
+
+      await CourierInboxDatastore.shared.clickMessageAction({
+        message,
+        action: { content: "Open", href: "https://x" },
+      });
+
+      expect(mockClick).not.toHaveBeenCalled();
+      expect(mockLoggerInfo).toHaveBeenCalledWith(
+        expect.stringContaining("no trackingId on the action")
+      );
+    });
+
+    it("swallows a click failure rather than throwing at the caller", async () => {
+      mockClick.mockRejectedValueOnce(new Error("network"));
+      const message: InboxMessage = {
+        ...getMessage(),
+        trackingIds: { clickTrackingId: "click-1" },
+      };
+
+      await expect(
+        CourierInboxDatastore.shared.clickMessage({ message })
+      ).resolves.toBeUndefined();
+      expect(mockLoggerError).toHaveBeenCalled();
     });
   });
 });

--- a/@trycourier/courier-ui-inbox/src/datastore/inbox-datastore.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/inbox-datastore.ts
@@ -1,4 +1,4 @@
-import { Courier, InboxMessage, InboxMessageEvent, InboxMessageEventEnvelope } from "@trycourier/courier-js";
+import { Courier, InboxAction, InboxMessage, InboxMessageEvent, InboxMessageEventEnvelope } from "@trycourier/courier-js";
 import { CourierGetInboxMessagesQueryFilter } from "@trycourier/courier-js/dist/types/inbox";
 import { CourierInboxDatasetFilter, CourierInboxFeed, InboxDataSet } from "../types/inbox-data-set";
 import { CourierInboxDataset } from "./inbox-dataset";
@@ -399,24 +399,85 @@ export class CourierInboxDatastore {
    * @param message - The message that was clicked
    */
   public async clickMessage({ message }: { message: InboxMessage }): Promise<void> {
+    // A missing clickTrackingId used to return here in total silence, which made a
+    // wire-shape problem look like a backend failure: socket-delivered messages
+    // nested trackingIds under `data`, this reads only the root, and the guard
+    // below swallowed the difference with no signal. iwpv=v2 fixes the shape; the
+    // log makes any remaining absence visible instead of indistinguishable from
+    // a successful no-op.
+    if (!message.trackingIds?.clickTrackingId) {
+      Courier.shared.client?.options.logger?.info(
+        `[${CourierInboxDatastore.TAG}] Not tracking click for message ${message.messageId}: no clickTrackingId on the message.`
+      );
+      return;
+    }
+
     // Clicking a message does not mutate it locally, but we still want error handling
-    if (message.trackingIds?.clickTrackingId) {
-      try {
-        await Courier.shared.client?.inbox.click({
-          messageId: message.messageId,
-          trackingId: message.trackingIds.clickTrackingId
-        });
-      } catch (error) {
-        // Log error
-        Courier.shared.client?.options.logger?.error(`[${CourierInboxDatastore.TAG}] Error clicking message:`, error);
+    try {
+      await Courier.shared.client?.inbox.click({
+        messageId: message.messageId,
+        trackingId: message.trackingIds.clickTrackingId
+      });
+    } catch (error) {
+      // Log error
+      Courier.shared.client?.options.logger?.error(`[${CourierInboxDatastore.TAG}] Error clicking message:`, error);
 
-        // Notify listeners of error
-        this._listeners.forEach(listener => {
-          listener.events.onError?.(error as Error);
-        });
+      // Notify listeners of error
+      this._listeners.forEach(listener => {
+        listener.events.onError?.(error as Error);
+      });
 
-        // Do NOT re-throw - swallow the error
-      }
+      // Do NOT re-throw - swallow the error
+    }
+  }
+
+  /**
+   * Track a click event for an action button on a message.
+   *
+   * Action clicks were never tracked at all — `onMessageActionClick` carried a
+   * standing `// TODO: Track action click?` and dispatched the event without
+   * recording anything, under any protocol version.
+   *
+   * Note this uses a different id from {@link clickMessage}: the per-action
+   * `action.data.trackingId`, not the message-level `trackingIds.clickTrackingId`.
+   * Both are minted server-side, but the action id identifies which button was
+   * pressed, so a message-level click id would lose that.
+   *
+   * @param message - The message whose action was clicked
+   * @param action - The action that was clicked
+   */
+  public async clickMessageAction({
+    message,
+    action
+  }: {
+    message: InboxMessage;
+    action: InboxAction;
+  }): Promise<void> {
+    const trackingId = action.data?.trackingId;
+
+    if (!trackingId) {
+      Courier.shared.client?.options.logger?.info(
+        `[${CourierInboxDatastore.TAG}] Not tracking action click for message ${message.messageId}: no trackingId on the action.`
+      );
+      return;
+    }
+
+    try {
+      await Courier.shared.client?.inbox.click({
+        messageId: message.messageId,
+        trackingId
+      });
+    } catch (error) {
+      Courier.shared.client?.options.logger?.error(
+        `[${CourierInboxDatastore.TAG}] Error clicking message action:`,
+        error
+      );
+
+      this._listeners.forEach(listener => {
+        listener.events.onError?.(error as Error);
+      });
+
+      // Do NOT re-throw - swallow the error, consistent with clickMessage
     }
   }
 


### PR DESCRIPTION
Ticket: [C-19800](https://linear.app/trycourier/issue/C-19800/inbox-socket-add-iwpvv2-with-a-canonical-message-payload-and-migrate)

> [!IMPORTANT]
> **Do not merge before trycourier/services#1527 is deployed.** The server downgrades an unrecognized `iwpv` to the *legacy* protocol rather than rejecting the connection, so shipping this first would silently move every client onto the legacy shape with no error.

## Clicking a socket-delivered message tracked nothing

The socket left `trackingIds` nested under `data`; the GraphQL read returned them at the root. This SDK reads **only** the root, and `clickMessage` was guarded on `message.trackingIds?.clickTrackingId` with no `else`:

```ts
if (message.trackingIds?.clickTrackingId) { await client.inbox.click({...}) }
```

So a live-delivered message fell through the guard and no click was recorded — while clicking the *same* message after a refresh worked, because the refetch supplied the GraphQL shape. That intermittency is what made it look like a backend problem.

`iwpv=v2` publishes the canonical message — the same object GraphQL returns, `trackingIds` at the root, no nested duplicate. The version bump is the fix.

## Two adjacent gaps, fixed here

| gap | before | after |
| --- | --- | --- |
| `clickMessage` with no `clickTrackingId` | returned in total silence — a wire-shape bug looked identical to a successful no-op | logs and returns early, so any remaining absence is visible |
| action-button clicks | **never tracked at all**, under any protocol version (`// TODO: Track action click?`) | new `clickMessageAction`, tracking on the per-action `action.data.trackingId` |

The action id is deliberately a *different* id from the message-level `clickTrackingId` — it identifies which button was pressed, which a message-level id would lose.

## Type surface

`InboxMessage` gains the remaining canonical fields: `icon`, `pinned`, `userId`, `content` (`html`/`elemental`, named after GraphQL's `FullMessage.content`), and `brandId` / `trackingUrl` — which v2 promotes out of `data` to match how the message is indexed and returned by GraphQL. `trackingIds` gains `channelTrackingId`. `data` is documented as no longer carrying the promoted keys.

## Tests

- **courier-js 47/47**, **courier-ui-inbox 66/66**
- Six new click-tracking cases: root-level id used; nested `data.trackingIds` copy correctly ignored; both absent-id paths log; action id used; click failure swallowed rather than thrown
- The socket test now pins `iwpv` to the exported constant **and** asserts that constant is `v2`, so a silent downgrade can't pass as a wrong-but-consistent value

Six courier-js suites fail to *collect* on `Missing required env var: USER_ID` — credential-gated E2E suites. I verified these are identical on the base commit with my changes stashed (6 failed / 8 passed either way), so they're pre-existing and unrelated.

## Not verified

Superseded — dev is healthy again (inbox-dev `UPDATE_COMPLETE`, ws-api task def rev 52, 1/1 running). The earlier blocker was not what I first diagnosed: the working `DRAGONFLY_API_KEY` lives in 1Password, and the `/courier/dev/dragonfly/*` entries in SSM/Secrets Manager describe a *different* Dragonfly instance than dev dials, which is why they returned `WRONGPASS` rather than being merely stale. The C-19789 `trackingIds` lift is now confirmed on a live dev socket end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
