### PR TITLE
fix(courier-ui-inbox): reconcile datasets on bulk archive and read

### DIFF
--- a/.changeset/inbox-bulk-archive-stale-copy.md
+++ b/.changeset/inbox-bulk-archive-stale-copy.md
@@ -1,0 +1,11 @@
+---
+"@trycourier/courier-ui-inbox": patch
+---
+
+Fix bulk archive and read leaving a message visible in the feed.
+
+`archiveAllMessages`, `readAllMessages`, `archiveReadMessages`, and the socket handler for the `archive-all` / `archive-read` / `mark-all-read` events all chose which messages to mutate by reading the datastore's global message store. Loading a dataset syncs its server results into that store but never overwrites an entry already present, so the global copy of a message can be further along than the copy a dataset is showing — already archived by an earlier archive-all, for instance, while the server still returns it as unarchived and a reload puts it back into the inbox dataset.
+
+Selecting from the global store in that state skipped the message, so its row stayed on screen and repeating the action could never clear it: the same check skipped it every time. Marking all as read appeared to fix it only because that path keys off `read` rather than `archived`.
+
+These operations now collect their candidates from the datasets as well as the global store, preferring a dataset's own copy, so they reconcile whatever is actually rendered.

--- a/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/__tests__/inbox-datastore.test.ts
@@ -747,4 +747,67 @@ describe("CourierInboxDatastore", () => {
       expect(onErrorMock).toHaveBeenCalledWith(expect.any(Error));
     });
   });
+
+  describe('bulk archive with a stale global copy', () => {
+
+    // A message can end up present in a dataset while the global store holds an
+    // older, already-archived copy of it: loading a dataset syncs server results
+    // into the global store but never overwrites an existing entry. When that
+    // happens the row is rendered but archiveAllMessages skips it, because the
+    // skip is decided from the global copy's archived flag rather than from what
+    // the datasets actually hold. The row then cannot be cleared by archiving.
+    it('archives a message the server still reports as unarchived, even if the global copy is already archived', async () => {
+      const MESSAGE = getMessage();
+
+      mockGetMessages.mockResolvedValue({
+        data: {
+          count: 1,
+          unreadCount: 1,
+          messages: { nodes: [MESSAGE] },
+        },
+      });
+      mockGetUnreadMessageCount.mockResolvedValue(1);
+
+      const datastore = CourierInboxDatastore.shared;
+      await datastore.load({ canUseCache: false });
+      expect(datastore.getDatasetById('inbox')?.messages.length).toBe(1);
+
+      // First archive-all works, and leaves the global copy marked archived.
+      await datastore.archiveAllMessages();
+      expect(datastore.getDatasetById('inbox')?.messages.length).toBe(0);
+
+      // The server still reports the message as unarchived, so a reload puts it
+      // back into the inbox dataset. The global copy stays archived.
+      await datastore.load({ canUseCache: false });
+      expect(datastore.getDatasetById('inbox')?.messages.length).toBe(1);
+
+      // Archiving again has to clear the row it is showing.
+      await datastore.archiveAllMessages();
+      expect(datastore.getDatasetById('inbox')?.messages.length).toBe(0);
+    });
+
+    it('archives read messages that are showing even if the global copy is already archived', async () => {
+      const MESSAGE = getMessage({ read: "2021-01-01" });
+
+      mockGetMessages.mockResolvedValue({
+        data: {
+          count: 1,
+          unreadCount: 0,
+          messages: { nodes: [MESSAGE] },
+        },
+      });
+      mockGetUnreadMessageCount.mockResolvedValue(0);
+
+      const datastore = CourierInboxDatastore.shared;
+      await datastore.load({ canUseCache: false });
+      await datastore.archiveReadMessages();
+      expect(datastore.getDatasetById('inbox')?.messages.length).toBe(0);
+
+      await datastore.load({ canUseCache: false });
+      expect(datastore.getDatasetById('inbox')?.messages.length).toBe(1);
+
+      await datastore.archiveReadMessages();
+      expect(datastore.getDatasetById('inbox')?.messages.length).toBe(0);
+    });
+  });
 });

--- a/@trycourier/courier-ui-inbox/src/datastore/inbox-datastore.ts
+++ b/@trycourier/courier-ui-inbox/src/datastore/inbox-datastore.ts
@@ -109,6 +109,45 @@ export class CourierInboxDatastore {
   }
 
   /**
+   * Collect the messages a bulk operation should mutate.
+   *
+   * Bulk operations can't decide this from `_globalMessages` alone. Loading
+   * a dataset syncs its server results into the global store but never overwrites
+   * an entry that is already there, so the global copy of a message can be more
+   * advanced than the copy a dataset is showing — for example already archived by
+   * an earlier archive-all, while the server still returns it as unarchived and a
+   * reload puts it back into the inbox dataset.
+   *
+   * Selecting from the global store in that state skips the message, so the row
+   * stays on screen and repeating the operation can never clear it. Including the
+   * datasets' own copies makes the operation reconcile whatever is rendered.
+   *
+   * @param shouldInclude - predicate identifying messages the operation applies to
+   * @returns one entry per message, preferring a dataset's copy over the global one
+   */
+  private collectMessagesForBulkUpdate(shouldInclude: (message: InboxMessage) => boolean): InboxMessage[] {
+    const messagesById = new Map<string, InboxMessage>();
+
+    for (const [messageId, message] of this._globalMessages.entries()) {
+      if (shouldInclude(message)) {
+        messagesById.set(messageId, message);
+      }
+    }
+
+    // A dataset's copy wins: it is the state the listeners have been told about,
+    // so it is the correct `before` for calculating the unread count change.
+    for (const dataset of this._datasets.values()) {
+      for (const message of dataset.toInboxDataset().messages) {
+        if (shouldInclude(message)) {
+          messagesById.set(message.messageId, message);
+        }
+      }
+    }
+
+    return Array.from(messagesById.values());
+  }
+
+  /**
    * Listen for real-time message updates from the Courier backend.
    *
    * If an existing WebSocket connection is open, it will be re-used. If not,
@@ -427,14 +466,13 @@ export class CourierInboxDatastore {
     await this.executeWithRollback(async () => {
       const archiveDate = CourierInboxDatastore.getISONow();
 
-      // Mutate all messages in global store that aren't already archived
-      for (const [messageId, beforeMessage] of this._globalMessages.entries()) {
-        if (!beforeMessage.archived) {
-          const afterMessage = copyMessage(beforeMessage);
-          afterMessage.archived = archiveDate;
-          this._globalMessages.set(messageId, afterMessage);
-          this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
-        }
+      // Mutate every known message that isn't already archived, taken from the
+      // datasets as well as the global store — see collectMessagesForBulkUpdate.
+      for (const beforeMessage of this.collectMessagesForBulkUpdate(message => !message.archived)) {
+        const afterMessage = copyMessage(beforeMessage);
+        afterMessage.archived = archiveDate;
+        this._globalMessages.set(beforeMessage.messageId, afterMessage);
+        this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
       }
 
       // Force non-archived dataset unread counts to 0.
@@ -458,14 +496,13 @@ export class CourierInboxDatastore {
     await this.executeWithRollback(async () => {
       const readDate = CourierInboxDatastore.getISONow();
 
-      // Mutate all messages in global store that aren't already read
-      for (const [messageId, beforeMessage] of this._globalMessages.entries()) {
-        if (!beforeMessage.read) {
-          const afterMessage = copyMessage(beforeMessage);
-          afterMessage.read = readDate;
-          this._globalMessages.set(messageId, afterMessage);
-          this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
-        }
+      // Mutate every known message that isn't already read, taken from the
+      // datasets as well as the global store — see collectMessagesForBulkUpdate.
+      for (const beforeMessage of this.collectMessagesForBulkUpdate(message => !message.read)) {
+        const afterMessage = copyMessage(beforeMessage);
+        afterMessage.read = readDate;
+        this._globalMessages.set(beforeMessage.messageId, afterMessage);
+        this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
       }
 
       // Force all dataset unread counts to 0.
@@ -487,14 +524,13 @@ export class CourierInboxDatastore {
     await this.executeWithRollback(async () => {
       const archiveDate = CourierInboxDatastore.getISONow();
 
-      // Mutate all read messages in global store that aren't already archived
-      for (const [messageId, beforeMessage] of this._globalMessages.entries()) {
-        if (beforeMessage.read && !beforeMessage.archived) {
-          const afterMessage = copyMessage(beforeMessage);
-          afterMessage.archived = archiveDate;
-          this._globalMessages.set(messageId, afterMessage);
-          this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
-        }
+      // Mutate every known read message that isn't already archived, taken from
+      // the datasets as well as the global store — see collectMessagesForBulkUpdate.
+      for (const beforeMessage of this.collectMessagesForBulkUpdate(message => !!message.read && !message.archived)) {
+        const afterMessage = copyMessage(beforeMessage);
+        afterMessage.archived = archiveDate;
+        this._globalMessages.set(beforeMessage.messageId, afterMessage);
+        this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
       }
 
       // Apply the archive to the server
@@ -676,36 +712,33 @@ export class CourierInboxDatastore {
   private updateAllMessages(event: InboxMessageEvent) {
     const timestamp = CourierInboxDatastore.getISONow();
 
-    for (const [messageId, beforeMessage] of this._globalMessages.entries()) {
-      let afterMessage: InboxMessage | null = null;
-
+    // Selected from the datasets as well as the global store, so an event can
+    // reconcile a rendered row whose global copy is already in the target state.
+    // See collectMessagesForBulkUpdate.
+    const applies = (message: InboxMessage): boolean => {
       switch (event) {
         case InboxMessageEvent.MarkAllRead:
-          if (!beforeMessage.read) {
-            afterMessage = copyMessage(beforeMessage);
-            afterMessage.read = timestamp;
-          }
-          break;
+          return !message.read;
         case InboxMessageEvent.ArchiveAll:
-          if (!beforeMessage.archived) {
-            afterMessage = copyMessage(beforeMessage);
-            afterMessage.archived = timestamp;
-          }
-          break;
+          return !message.archived;
         case InboxMessageEvent.ArchiveRead:
-          if (beforeMessage.read && !beforeMessage.archived) {
-            afterMessage = copyMessage(beforeMessage);
-            afterMessage.archived = timestamp;
-          }
-          break;
+          return !!message.read && !message.archived;
         default:
-          break;
+          return false;
+      }
+    };
+
+    for (const beforeMessage of this.collectMessagesForBulkUpdate(applies)) {
+      const afterMessage = copyMessage(beforeMessage);
+
+      if (event === InboxMessageEvent.MarkAllRead) {
+        afterMessage.read = timestamp;
+      } else {
+        afterMessage.archived = timestamp;
       }
 
-      if (afterMessage) {
-        this._globalMessages.set(messageId, afterMessage);
-        this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
-      }
+      this._globalMessages.set(beforeMessage.messageId, afterMessage);
+      this.updateDatasetsWithMessageChange(beforeMessage, afterMessage);
     }
 
     // Force dataset unread counts to 0 for bulk operations where the loop


### PR DESCRIPTION
## The bug

Archiving all messages could leave one row on screen. The message was archived on the server and gone from the feed there — it was stuck in the client only. Clicking archive-all again never cleared it, but marking all as read did.

## Cause

Bulk operations chose which messages to mutate by reading the datastore's global message store, while what the user sees comes from the datasets. Those two can disagree, because `syncDatasetMessagesToGlobalStore` only inserts messages it doesn't already have:

```ts
if (!this._globalMessages.has(message.messageId)) {   // never overwrites
```

So the global copy can be further along than the copy a dataset is showing — already archived by an earlier archive-all, for example, while the server still returns it as unarchived and a reload puts it back into the inbox dataset.

In that state `archiveAllMessages` hit `if (!beforeMessage.archived)`, skipped the message, and never called `updateDatasetsWithMessageChange`. The row survived, and repeating the action could not fix it because the same check skipped it every time.

Marking all as read appeared to fix it for an instructive reason: `readAllMessages` keys off `read`, not `archived`. For an unread message it built an `after` state that still carried `archived`, handed it to the datasets, and there it failed the inbox filter and was finally evicted. Same stale state, different guard — which is what identified the faulty line.

## The fix

`collectMessagesForBulkUpdate(predicate)` gathers candidates from the datasets as well as the global store, preferring a dataset's own copy. That copy is the state listeners were told about, so it is also the correct `before` for the unread-count delta.

Applied to all four paths that shared the defect:

- `archiveAllMessages`
- `readAllMessages`
- `archiveReadMessages`
- `updateAllMessages` — the socket handler for `archive-all` / `archive-read` / `mark-all-read`, which had the identical skip logic and so couldn't self-heal from a server event either

## Why this shape

The alternative is making the sync overwrite existing entries so global and dataset copies can't diverge. That guard is presumably there to stop a slower dataset load from clobbering an in-flight optimistic mutation, so removing it risks regressions in a wider area. Making the bulk operations tolerate divergence is the narrower change.

Worth a follow-up: the guard still permits a stale global copy, and single-message paths read from that store too (`updateMessage` bails when the id is missing), so there may be sibling issues on the same seam.

## Testing

Two regression tests added, written first and confirmed failing before the fix (`Expected: 0, Received: 1`) — one for archive-all, one for archive-read.

- `@trycourier/courier-ui-inbox`: 62 passed
- Also green: courier-js 108, courier-ui-toast 67, courier-ui-preferences 49, courier-react 18, courier-react-17 7
- `yarn build-packages:ci` clean, no API report drift

The `@trycourier/courier-vue` suite fails locally on `Missing required env var: USER_ID`; its E2E tests need their own env file. Pre-existing and unrelated.

Includes a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
