### PR TITLE
Bump the three packages the release keeps tripping over

### DIFF
--- a/.changeset/lucky-jars-listen.md
+++ b/.changeset/lucky-jars-listen.md
@@ -1,0 +1,9 @@
+---
+"@trycourier/courier-js": patch
+"@trycourier/courier-ui-core": patch
+"@trycourier/courier-ui-preferences": patch
+---
+
+Version bump only, so every package moves to a version the registry has not seen. No functional change.
+
+These three sat at versions already on npm while the rest of the packages released, and `changeset publish` attempts every package on each run — the already-published ones come back rejected and take the whole Release run down with them.


### PR DESCRIPTION
Makes the Release run green again: https://github.com/trycourier/courier-web/actions/runs/32171313975

## What happened

That run **did** release. Seven packages published:

`courier-angular@1.0.8` · `courier-react@9.2.11` · `courier-react-17@9.2.11` · `courier-react-components@2.2.11` · `courier-ui-inbox@2.5.2` · `courier-ui-toast@2.2.0` · `courier-vue@1.0.8`

It exited 1 on the other three, which had no new version to publish:

| Package | Version | On npm |
| --- | --- | --- |
| `@trycourier/courier-js` | 3.5.0 | since Jul 15 |
| `@trycourier/courier-ui-core` | 2.3.0 | since Jul 15 |
| `@trycourier/courier-ui-preferences` | 1.2.1 | since Jul 15 |

`changeset publish` attempts every package on every run rather than only the ones whose versions moved, so those three came back `You cannot publish over the previously published versions` and took the run's exit code with them.

## The bump

A patch on each of the three. Through the dependent cascade that moves all ten packages to versions the registry has not seen, so the next publish has something to do for every one of them:

| Package | Target | |
| --- | --- | --- |
| `courier-js` | 3.5.1 | changeset |
| `courier-ui-core` | 2.3.1 | changeset |
| `courier-ui-preferences` | 1.2.2 | changeset |
| `courier-ui-inbox` | 2.5.3 | cascade |
| `courier-ui-toast` | 2.2.1 | cascade |
| `courier-react` | 9.2.12 | cascade |
| `courier-react-17` | 9.2.12 | cascade |
| `courier-react-components` | 2.2.12 | cascade |
| `courier-vue` | 1.0.9 | cascade |
| `courier-angular` | 1.0.9 | cascade |

Verified with `yarn changeset status --verbose`. The changeset says plainly that it is a version bump with no functional change, since that text lands in each package's changelog.

## Worth knowing before merging

This clears the current red run, and it holds as long as every release moves every package. The next time a changeset touches only part of the tree — say one `courier-ui-inbox` fix — the packages it does not reach will sit at published versions again and the run goes red the same way. Five of the last seven Release runs failed on exactly this.

The durable fix is at the workflow level: changesets' `npm info` check reports every package as unpublished under OIDC (`NPM_TOKEN: ''` in `release.yml`), which is why it tries to publish all ten in the first place. Happy to dig into that separately — I did not want to guess at it inside a release-critical workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
