### PR TITLE
example(photo-shoot): export at 4x and give the card an even gutter

### DIFF
--- a/examples/react-latest/src/PhotoShootCustomRender.tsx
+++ b/examples/react-latest/src/PhotoShootCustomRender.tsx
@@ -5,7 +5,7 @@ import {
   type CourierInboxListItemFactoryProps,
 } from '@trycourier/courier-react';
 import { createPeopleMessages, personFor } from './previewPeople';
-import PhotoShootStage, { photoShootTheme } from './PhotoShootStage';
+import PhotoShootStage, { PhotoShootCard, photoShootTheme } from './PhotoShootStage';
 import { COMPONENT_BORDER } from './photoShootThemes';
 
 const FONT = "'Poppins', system-ui, sans-serif";
@@ -106,34 +106,16 @@ export default function PhotoShootCustomRender() {
 
   return (
     <PhotoShootStage fileName="courier-inbox-custom-render">
-      <div
-        style={{
-          height: '100%',
-          boxSizing: 'border-box',
-          padding: '16px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <div
-          style={{
-            width: '620px',
-            backgroundColor: '#ffffff',
-            border: `1px solid ${COMPONENT_BORDER}`,
-            borderRadius: '12px',
-            overflow: 'hidden',
-          }}
-        >
-          <CourierInbox
-            mode="light"
-            lightTheme={photoShootTheme}
-            previewMessages={previewMessages}
-            renderHeader={props => (props ? <CustomHeader {...props} /> : <></>)}
-            renderListItem={props => (props ? <CustomListItem {...props} /> : <></>)}
-          />
-        </div>
-      </div>
+      <PhotoShootCard>
+        <CourierInbox
+          mode="light"
+          height="100%"
+          lightTheme={photoShootTheme}
+          previewMessages={previewMessages}
+          renderHeader={props => (props ? <CustomHeader {...props} /> : <></>)}
+          renderListItem={props => (props ? <CustomListItem {...props} /> : <></>)}
+        />
+      </PhotoShootCard>
     </PhotoShootStage>
   );
 

--- a/examples/react-latest/src/PhotoShootInbox.tsx
+++ b/examples/react-latest/src/PhotoShootInbox.tsx
@@ -1,47 +1,27 @@
 import { useMemo } from 'react';
 import { CourierInbox } from '@trycourier/courier-react';
 import { createPreviewMessages } from './previewMessages';
-import PhotoShootStage, { photoShootTheme } from './PhotoShootStage';
-import { COMPONENT_BORDER } from './photoShootThemes';
+import PhotoShootStage, { PhotoShootCard, photoShootTheme } from './PhotoShootStage';
 
 /** Photo shoot: the inbox as a centered card. */
 export default function PhotoShootInbox() {
 
   // Preview messages render without a sign-in or any network calls. Every message
-  // carries an action, so three fill the frame without the card outgrowing it.
+  // carries an action, so three fill the card's fixed height without leaving a gap.
   const previewMessages = useMemo(() => createPreviewMessages().slice(0, 3), []);
 
   return (
     <PhotoShootStage fileName="courier-inbox-card">
-      <div
-        style={{
-          height: '100%',
-          boxSizing: 'border-box',
-          padding: '16px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        {/* The inbox has no background/border of its own, so the card supplies
-            both, in the border the component draws internally. The width is set
-            so every message fits the frame without the list scrolling. */}
-        <div
-          style={{
-            width: '700px',
-            backgroundColor: '#ffffff',
-            border: `1px solid ${COMPONENT_BORDER}`,
-            borderRadius: '12px',
-            overflow: 'hidden',
-          }}
-        >
-          <CourierInbox
-            mode="light"
-            lightTheme={photoShootTheme}
-            previewMessages={previewMessages}
-          />
-        </div>
-      </div>
+      {/* The inbox has no background/border of its own, so the card supplies
+          both, in the border the component draws internally. */}
+      <PhotoShootCard>
+        <CourierInbox
+          mode="light"
+          height="100%"
+          lightTheme={photoShootTheme}
+          previewMessages={previewMessages}
+        />
+      </PhotoShootCard>
     </PhotoShootStage>
   );
 

--- a/examples/react-latest/src/PhotoShootStage.tsx
+++ b/examples/react-latest/src/PhotoShootStage.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState, type MouseEvent, type ReactNode } from 'react';
 import { domToPng } from 'modern-screenshot';
 import { type CourierInboxTheme } from '@trycourier/courier-react';
+import { COMPONENT_BORDER } from './photoShootThemes';
 
 /**
  * Scrollbars read as clutter in a still, so the shots hide them. The width feeds
@@ -16,11 +17,65 @@ export const photoShootTheme: CourierInboxTheme = {
   },
 };
 
+/** The CSS size of the frame every shot is composed inside. */
+const STAGE_WIDTH = 788;
+const STAGE_HEIGHT = 444;
+
+/**
+ * Device-pixel multiplier for the export. The stage is vector — copy, borders,
+ * and the components' inline SVG icons all re-render at this density rather than
+ * being scaled up — so the ceiling is the one raster the shots contain: the
+ * sender photos in [previewPeople], requested at a size that covers this value.
+ */
+const EXPORT_SCALE = 4;
+
+/**
+ * The inset between the stage edge and a card sitting inside it, on all four
+ * sides — the shots used to carry a different gap on each axis.
+ */
+const STAGE_GUTTER = 24;
+
 type PhotoShootStageProps = {
   /** Name of the exported file, without an extension. */
   fileName: string;
   children: ReactNode;
 };
+
+/**
+ * A card inset from the stage by [STAGE_GUTTER] on every side — 740x396 inside
+ * the 788x444 frame.
+ *
+ * The height is fixed here rather than left to the content, which is the part
+ * that makes the gutter even: a card that sizes to its own content can only be
+ * centred, so its top and bottom gaps come out at whatever the content leaves
+ * over, and match the sides only by coincidence. Give the child `height="100%"`
+ * so it fills the card the frame guarantees.
+ */
+export function PhotoShootCard({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: '100%',
+        boxSizing: 'border-box',
+        padding: `${STAGE_GUTTER}px`,
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          boxSizing: 'border-box',
+          backgroundColor: '#ffffff',
+          border: `1px solid ${COMPONENT_BORDER}`,
+          borderRadius: '12px',
+          overflow: 'hidden',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
 
 /**
  * The 788x444 area the photo shoot examples are screenshotted from. Everything
@@ -44,7 +99,7 @@ export default function PhotoShootStage({ fileName, children }: PhotoShootStageP
     try {
       // The components draw their icons and buttons inside open shadow roots,
       // so the capture has to descend into them — modern-screenshot does.
-      const dataUrl = await domToPng(stage, { scale: 2, backgroundColor: '#eef0f4' });
+      const dataUrl = await domToPng(stage, { scale: EXPORT_SCALE, backgroundColor: '#eef0f4' });
       const link = document.createElement('a');
       link.download = `${fileName}.png`;
       link.href = dataUrl;
@@ -67,7 +122,7 @@ export default function PhotoShootStage({ fileName, children }: PhotoShootStageP
         backgroundColor: '#ffffff',
       }}
     >
-      <div style={{ width: '788px', display: 'flex', justifyContent: 'flex-end' }}>
+      <div style={{ width: `${STAGE_WIDTH}px`, display: 'flex', justifyContent: 'flex-end' }}>
         <button
           onClick={exportPng}
           disabled={exporting}
@@ -80,7 +135,9 @@ export default function PhotoShootStage({ fileName, children }: PhotoShootStageP
             cursor: exporting ? 'default' : 'pointer',
           }}
         >
-          {exporting ? 'Exporting…' : 'Export PNG (1576x888)'}
+          {exporting
+            ? 'Exporting…'
+            : `Export PNG (${STAGE_WIDTH * EXPORT_SCALE}x${STAGE_HEIGHT * EXPORT_SCALE})`}
         </button>
       </div>
 
@@ -90,8 +147,8 @@ export default function PhotoShootStage({ fileName, children }: PhotoShootStageP
         <div
           ref={stageRef}
           style={{
-            width: '788px',
-            height: '444px',
+            width: `${STAGE_WIDTH}px`,
+            height: `${STAGE_HEIGHT}px`,
             backgroundColor: '#eef0f4',
             overflow: 'hidden',
           }}

--- a/examples/react-latest/src/PhotoShootTheme.tsx
+++ b/examples/react-latest/src/PhotoShootTheme.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { CourierInbox } from '@trycourier/courier-react';
 import { createPreviewMessages } from './previewMessages';
-import PhotoShootStage from './PhotoShootStage';
-import { COMPONENT_BORDER, inboxTheme } from './photoShootThemes';
+import PhotoShootStage, { PhotoShootCard } from './PhotoShootStage';
+import { inboxTheme } from './photoShootThemes';
 
 /** Photo shoot: "A Courier Inbox with a custom theme" */
 export default function PhotoShootTheme() {
@@ -12,32 +12,14 @@ export default function PhotoShootTheme() {
 
   return (
     <PhotoShootStage fileName="courier-inbox-theme">
-      <div
-        style={{
-          height: '100%',
-          boxSizing: 'border-box',
-          padding: '16px',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <div
-          style={{
-            width: '700px',
-            backgroundColor: '#ffffff',
-            border: `1px solid ${COMPONENT_BORDER}`,
-            borderRadius: '12px',
-            overflow: 'hidden',
-          }}
-        >
-          <CourierInbox
-            mode="light"
-            lightTheme={inboxTheme}
-            previewMessages={previewMessages}
-          />
-        </div>
-      </div>
+      <PhotoShootCard>
+        <CourierInbox
+          mode="light"
+          height="100%"
+          lightTheme={inboxTheme}
+          previewMessages={previewMessages}
+        />
+      </PhotoShootCard>
     </PhotoShootStage>
   );
 

--- a/examples/react-latest/src/previewPeople.ts
+++ b/examples/react-latest/src/previewPeople.ts
@@ -14,9 +14,13 @@ export type Person = {
  * Photos are Unsplash URLs. Unsplash is one of the few image hosts that sends
  * `access-control-allow-origin`, which the PNG export needs to inline them; hosts
  * without it (pravatar, randomuser) show on screen but export blank.
+ *
+ * These are the only raster in the photo shoot, so they set its resolution
+ * ceiling. Unsplash resizes server-side, so ask for enough to stay sharp at the
+ * stage's export scale: a 36px avatar needs 36 x EXPORT_SCALE, with room to spare.
  */
 const photo = (id: string) =>
-  `https://images.unsplash.com/${id}?w=160&h=160&fit=crop&crop=faces&q=80`;
+  `https://images.unsplash.com/${id}?w=320&h=320&fit=crop&crop=faces&q=80`;
 
 export const PEOPLE: Record<string, Person> = {
   dana: {


### PR DESCRIPTION
## What

Two changes to the `react-latest` photo shoot stages.

**Export resolution.** `domToPng` was capturing at `scale: 2`, so every shot came out 1576x888. It now uses an `EXPORT_SCALE` constant set to 4 — 3152x1776. This is real resolution rather than upscaling: the stages are text, borders, and the components' inline SVG icons, all of which re-rasterize at whatever density is asked for.

The one exception is the sender photos in the custom-render shot, the only raster anywhere in the shoot. They were requested from Unsplash at `w=160&h=160`, which a 36px avatar at 4x would have consumed exactly, with nothing spare. They now come back at 320 so there is headroom past 4x. Unsplash resizes server-side, so this costs a few KB and no build time.

The button label and the stage's width/height literals are derived from the same constants, so `EXPORT_SCALE` is the only edit needed next time and the label can't drift from what it actually produces.

**Even gutter.** The card shots carried 16px top and bottom against a 44-84px side gutter. A card sized to its own content can only be centred, so its top and bottom gaps land wherever the content leaves off and match the sides by coincidence. The three large-inbox shots now share a `PhotoShootCard` — a fixed 740x396 box inset 24px on all four sides, with the inbox given `height="100%"` to fill it.

Applied to the Inbox, Theme, and CustomRender shots. Deliberately left alone: Delivered (a single message would leave a 396px card mostly empty), Split (full-bleed by design), Popup and Toast (anchored/floating, no card), and Preferences (a top-aligned scrolling form — uneven too, but filling it vertically would change the composition).

## Testing

Typechecks clean; the pre-existing errors in `CustomMenuButton`, `CustomOther`, and `PreferencesStyled` are untouched. Both photo shoot themes already hide the list scrollbar, so a list that now slightly overflows the fixed card won't show one.

Not yet checked in a browser — the framing and whether three messages comfortably fill the taller card is a visual call. `STAGE_GUTTER` is the single number to tune, and the `slice(0, n)` in each shot sets the fill.

No changeset: this touches `examples/` only, no published package source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)